### PR TITLE
Add a minimal hello_web example

### DIFF
--- a/examples/hello_web/Cargo.toml
+++ b/examples/hello_web/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "hello_web"
+version = "0.1.0"
+authors = ["Sergey \"Shnatsel\" Davidoff <shnatsel@gmail.com>"]
+
+[dependencies]
+stdweb = "*"

--- a/examples/hello_web/src/main.rs
+++ b/examples/hello_web/src/main.rs
@@ -1,0 +1,8 @@
+#[macro_use]
+extern crate stdweb;
+
+fn main() {
+    stdweb::initialize();
+    js! { console.log( @{"Hello, 世界!"} ) };
+    stdweb::event_loop();
+}


### PR DESCRIPTION
Add a convenient starting point for a Rust web project with very basic crate usage.

Something like this might be useful in `cargo web`

`console.log` was chosen over `alert` because it also works in node.js; may or may not be a good idea.

Should I also add an HTML that calls the .js file? If so, how do I call the JS? The todomvc example looks for the code in js/app.js and that's not where `cargo build --target=asmjs-unknown-emscripten` puts it. I imagine there is some magic that `cargo web` does in this case, but I'd strongly favor a "batteries included" kind of hello world :smile_cat: 