### PR TITLE
Export Value in private module

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -208,6 +208,7 @@ pub mod private {
     };
 
     pub use webcore::value::{
+        Value,
         FromReference,
         FromReferenceUnchecked
     };


### PR DESCRIPTION
I need to create pass around a custom JS type without serializing it.
I guess there is a good reason that you have not exported the Value type so I thought exporting it from the private module could be an ok solution for now.