### PR TITLE
Publish TextNode struct

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -130,6 +130,7 @@ pub mod web {
     pub use webapi::event_target::{IEventTarget, EventTarget, EventListenerHandle};
     pub use webapi::node::{INode, Node, CloneKind};
     pub use webapi::element::{IElement, Element};
+    pub use webapi::text_node::TextNode;
     pub use webapi::html_element::{IHtmlElement, HtmlElement};
     pub use webapi::window_or_worker::IWindowOrWorker;
     pub use webapi::token_list::TokenList;


### PR DESCRIPTION
[`Document::create_text_node`](https://docs.rs/stdweb/*/stdweb/web/struct.Document.html#method.create_text_node) returns `TextNode` struct, but actually it's private and cannot be imported:

```rust
error[E0432]: unresolved import `stdweb::web::TextNode`
  |
9 | use stdweb::web::{INode, IElement, Node, Element, TextNode, document};
  |                                                   ^^^^^^^^ no `TextNode` in `web`
```

This PR fixes it.