### PR TITLE
Implement bindings to the History API

### DIFF
--- a/examples/history/Cargo.toml
+++ b/examples/history/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "history"
+version = "0.1.0"
+authors = ["Tom Houlé <tom@tomhoule.com>"]
+
+[dependencies]
+serde = "1"
+serde_json = "1"
+serde_derive = "1"
+stdweb = { path = "../.." }

--- a/examples/history/src/main.rs
+++ b/examples/history/src/main.rs
@@ -1,0 +1,55 @@
+#[macro_use]
+extern crate stdweb;
+
+extern crate serde;
+#[macro_use]
+extern crate serde_derive;
+extern crate serde_json as json;
+
+use stdweb::unstable::TryInto;
+use stdweb::serde::Serde;
+use stdweb::web::event::PopStateEvent;
+use stdweb::web::{
+    IEventTarget,
+    History,
+    set_timeout,
+    window,
+};
+
+#[derive(Debug, Deserialize, Serialize)]
+struct ExampleState {
+    numero: i32,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+struct WrongState {
+    cheese: String,
+}
+
+js_serializable!(ExampleState);
+
+fn pop_listener(event: PopStateEvent) {
+    let state: Option<Serde<ExampleState>> = event.state().try_into().ok();
+    let state_str = format!("state_str({:?})", state);
+    js!(console.log("pop event!!", @{state_str}, @{state}));
+    let wrong_state: Option<Serde<WrongState>> = event.state().try_into().ok();
+    let wrong_state_str = format!("wrong_state_str({:?})", wrong_state);
+    js!(console.log("should be null", @{wrong_state_str}));
+}
+
+fn main() {
+    stdweb::initialize();
+    let history: History = window().history();
+    let state = ExampleState { numero: 1 };
+    window().add_event_listener(pop_listener);
+    let history_length = history.len();
+    js!(console.log("number of history entries: ", @{history_length}));
+    history.push_state(state, "", Some("cat_pics.html"));
+    set_timeout(|| window().history().back(), 2000);
+    set_timeout(|| window().history().forward(), 5000);
+    set_timeout(|| window().history().back(), 8000);
+    set_timeout(move || {
+        let history_length = window().history().len();
+        js!(console.log("number of history entries: ", @{history_length}));
+    }, 9000);
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -146,6 +146,7 @@ pub mod web {
     pub use webapi::array_buffer::ArrayBuffer;
     pub use webapi::typed_array::TypedArray;
     pub use webapi::file_reader::{FileReader, FileReaderResult};
+    pub use webapi::history::History;
 
 
     /// A module containing XMLHttpRequest and its ReadyState
@@ -201,6 +202,7 @@ pub mod web {
             ProgressErrorEvent,
             InputEvent,
             ReadyStateChange,
+            PopStateEvent,
         };
     }
 }

--- a/src/webapi/history.rs
+++ b/src/webapi/history.rs
@@ -1,0 +1,90 @@
+use webcore::value::Reference;
+use webcore::try_from::TryInto;
+use webcore::serialization::JsSerializable;
+
+/// [(JavaScript docs)](https://developer.mozilla.org/en-US/docs/Web/API/History)
+pub struct History(Reference);
+
+reference_boilerplate! {
+    History,
+    instanceof History
+}
+
+impl History {
+    /// Adds a new entry to history.
+    ///
+    /// pushState() takes three parameters: a state object, a title (which is currently ignored),
+    /// and (optionally) a URL. Let's examine each of these three parameters in more detail:
+    ///
+    /// - state object — The state object is a JavaScript object which is associated with the new
+    /// history entry created by pushState(). Whenever the user navigates to the new state, a
+    /// popstate event is fired, and the state property of the event contains a copy of the history
+    /// entry's state object.
+    ///
+    /// - title — Firefox currently ignores this parameter, although it may use it in the future.
+    /// Passing the empty string here should be safe against future changes to the method.
+    /// Alternatively, you could pass a short title for the state to which you're moving.
+    ///
+    /// - URL — The new history entry's URL is given by this parameter. Note that the browser won't
+    /// attempt to load this URL after a call to pushState(), but it might attempt to load the URL
+    /// later, for instance after the user restarts the browser. The new URL does not need to be
+    /// absolute; if it's relative, it's resolved relative to the current URL. The new URL must be
+    /// of the same origin as the current URL; otherwise, pushState() will throw an exception.
+    /// This parameter is optional; if it isn't specified, it's set to the document's current URL.
+    ///
+    /// [(JavaScript docs)](https://developer.mozilla.org/en-US/docs/Web/API/History_API#The_pushState%28%29_method)
+    pub fn push_state<T: JsSerializable>(&self, state: T, title: &str, url: Option<&str>) {
+        js!{ @(no_return)
+            @{self}.pushState(@{state}, @{title}, @{url});
+        };
+    }
+
+    /// Operates exactly like history.push_state() except that replace_state() modifies the current
+    /// history entry instead of creating a new one. Note that this doesn't prevent the creation of
+    /// a new entry in the global browser history.
+    ///
+    /// [(JavaScript docs)](https://developer.mozilla.org/en-US/docs/Web/API/History_API#The_replaceState%28%29_method)
+    pub fn replace_state<T: JsSerializable>(&self, state: T, title: &str, url: Option<&str>) {
+        js!{ @(no_return)
+            @{self}.replaceState(@{state}, @{title}, @{url});
+        };
+    }
+
+    /// You can use the go() method to load a specific page from session history, identified by its
+    /// relative position to the current page (with the current page being, of course, relative
+    /// index 0).
+    ///
+    /// [(JavaScript docs)](https://developer.mozilla.org/en-US/docs/Web/API/History_API#Traveling_through_history)
+    pub fn go(&self, offset: i32) {
+        js! { @(no_return)
+            @{self}.go(@{offset});
+        };
+    }
+
+    /// Move one step backward through history.
+    ///
+    /// [(JavaScript docs)](https://developer.mozilla.org/en-US/docs/Web/API/History_API#Traveling_through_history)
+    pub fn back(&self) {
+        js! { @(no_return)
+            @{self}.back();
+        };
+    }
+
+    /// Move one step forward through history.
+    ///
+    /// [(JavaScript docs)](https://developer.mozilla.org/en-US/docs/Web/API/History_API#Traveling_through_history)
+    pub fn forward(&self) {
+        js! { @(no_return)
+            @{self}.forward();
+        };
+    }
+
+    /// Returns the current number of history entries.
+    ///
+    /// [(JavaScript docs)](https://developer.mozilla.org/en-US/docs/Web/API/History)
+    pub fn len(&self) -> usize {
+        js!(
+            return @{self}.length;
+        ).try_into().unwrap()
+    }
+}

--- a/src/webapi/mod.rs
+++ b/src/webapi/mod.rs
@@ -24,3 +24,4 @@ pub mod array_buffer;
 pub mod typed_array;
 /// A module containing XMLHttpRequest and its ReadyState
 pub mod xml_http_request;
+pub mod history;

--- a/src/webapi/window.rs
+++ b/src/webapi/window.rs
@@ -3,6 +3,7 @@ use webapi::event_target::{IEventTarget, EventTarget};
 use webapi::window_or_worker::IWindowOrWorker;
 use webapi::storage::Storage;
 use webapi::location::Location;
+use webapi::history::History;
 use webcore::once::Once;
 use webcore::value::Value;
 
@@ -125,5 +126,17 @@ impl Window {
             return { request: request, callback: callback, window: @{self} };
         };
         RequestAnimationFrameHandle(values)
+    }
+
+    /// Returns the global [History](struct.History.html) object, which provides methods to
+    /// manipulate the browser history.
+    ///
+    /// [(JavaScript docs)](https://developer.mozilla.org/en-US/docs/Web/API/Window/history)
+    pub fn history(&self) -> History {
+        unsafe {
+            js!(
+                return @{self}.history;
+            ).into_reference_unchecked().unwrap()
+        }
     }
 }


### PR DESCRIPTION
They work in the small example included in the PR. There are however a few questions left open:

- I don't think the unit test for `PopStateEvent` is run, it never fails.
- Is the signature for `History::state` the preferred way to extract typed values from js?
- Should the example stay there? It might gain from being a bit less trivial in that case.
- Is the code formatted correctly?

Looking forward to your feedback :)