### PR TITLE
Added XMLHttpRequest support

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -147,6 +147,11 @@ pub mod web {
     pub use webapi::typed_array::TypedArray;
     pub use webapi::file_reader::{FileReader, FileReaderResult};
 
+
+    /// A module containing XMLHttpRequest and its ReadyState
+    pub mod xml_http_request {
+        pub use webapi::xml_http_request::{ XMLHttpRequest, ReadyState };
+    }
     /// A module containing error types.
     pub mod error {
         pub use webapi::node::NotFoundError;
@@ -193,7 +198,8 @@ pub mod web {
             ProgressLoadEvent,
             ProgressAbortEvent,
             ProgressErrorEvent,
-            InputEvent
+            InputEvent,
+            ReadyStateChange,
         };
     }
 }

--- a/src/webapi/event.rs
+++ b/src/webapi/event.rs
@@ -1104,6 +1104,23 @@ reference_boilerplate! {
     convertible to ProgressRelatedEvent
 }
 
+/// The readystatechange event is fired when the readyState attribute of a document has changed.
+///
+/// [(JavaScript docs)](https://developer.mozilla.org/en-US/docs/Web/Events/readystatechange)
+pub struct ReadyStateChange( Reference );
+
+reference_boilerplate! {
+    ReadyStateChange,
+    instanceof Event
+    convertible to Event
+}
+
+impl IEvent for ReadyStateChange {}
+
+impl ConcreteEvent for ReadyStateChange {
+    const EVENT_TYPE: &'static str = "readystatechange";
+}
+
 #[cfg(all(test, feature = "web_test"))]
 mod tests {
     use super::*;
@@ -1338,5 +1355,13 @@ mod tests {
             return new ProgressEvent( @{LoadEndEvent::EVENT_TYPE} );
         ).try_into().unwrap();
         assert_eq!( event.event_type(), LoadEndEvent::EVENT_TYPE );
+    }
+
+    #[test]
+    fn test_ready_state_change_event() {
+        let event: ReadyStateChange = js!(
+            return new Event( @{ReadyStateChange::EVENT_TYPE} );
+        ).try_into().unwrap();
+        assert_eq!( event.event_type(), ReadyStateChange::EVENT_TYPE);
     }
 }

--- a/src/webapi/mod.rs
+++ b/src/webapi/mod.rs
@@ -22,3 +22,5 @@ pub mod file_list;
 pub mod file_reader;
 pub mod array_buffer;
 pub mod typed_array;
+/// A module containing XMLHttpRequest and its ReadyState
+pub mod xml_http_request;

--- a/src/webapi/xml_http_request.rs
+++ b/src/webapi/xml_http_request.rs
@@ -1,0 +1,132 @@
+use webapi::event_target::{IEventTarget, EventTarget};
+use webcore::unsafe_typed_array::UnsafeTypedArray;
+use webcore::value::{
+    Reference,
+    Value,
+};
+use webcore::try_from::TryInto;
+
+/// Use XMLHttpRequest (XHR) objects to interact with servers.
+/// You can retrieve data from a URL without having to do a full page refresh.
+/// This enables a Web page to update just part of a page without disrupting
+/// what the user is doing. XMLHttpRequest is used heavily in Ajax programming.
+/// 
+/// [(JavaScript docs)](https://developer.mozilla.org/en-US/docs/Web/API/XMLHttpRequest)
+pub struct XMLHttpRequest( Reference );
+
+reference_boilerplate! {
+    XMLHttpRequest,
+    instanceof XMLHttpRequest
+    convertible to EventTarget
+}
+
+/// An enum indicating the state of the `XMLHttpRequest`.
+///
+/// [(JavaScript docs)](https://developer.mozilla.org/en-US/docs/Web/API/XMLHttpRequest/readyState)
+#[derive(Copy, Clone, PartialEq, Eq, Debug)]
+pub enum ReadyState {
+    /// Client has been created. [open()](struct.XMLHttpRequest.html#method.open) not called yet.
+    Unsent,
+    /// [open()](struct.XMLHttpRequest.html#method.open) has been called.
+    Opened,
+    /// [send()](struct.XMLHttpRequest.html#method.send) has been called, and headers and [status()](struct.XMLHttpRequest.html#method.status) are available.
+    HeadersReceived,
+    /// Downloading; [reponse_text()](struct.XMLHttpRequest.html#method.reponse_text) holds partial data.
+    Loading,
+    /// The operation is complete.
+    Done,
+}
+
+impl IEventTarget for XMLHttpRequest {}
+
+
+impl XMLHttpRequest {
+    /// Creates new `XMLHttpRequest`.
+    pub fn new() -> XMLHttpRequest {
+        js!( return new XMLHttpRequest(); ).try_into().unwrap()
+    }
+
+    /// Returns the current state of the request as a [ReadyState](enum.ReadyState.html). 
+    ///
+    /// [(JavaScript docs)](https://developer.mozilla.org/en-US/docs/Web/API/XMLHttpRequest/readyState)
+    pub fn ready_state(&self) -> ReadyState {
+        use self::ReadyState::*;
+        let state: u16 = js!( return @{self}.readyState; ).try_into().unwrap();
+        match state {
+            0 => Unsent,
+            1 => Opened,
+            2 => HeadersReceived,
+            3 => Loading,
+            4 => Done,
+            _ => unreachable!( "Unexpected value of XMLHttpRequest::readyState: {}", state )
+        }
+    }
+
+    /// Returns a string that contains the response to the request as text, or None
+    /// if the request was unsuccessful or has not yet been sent.
+    ///
+    ///[(JavaScript docs)](https://developer.mozilla.org/en-US/docs/Web/API/XMLHttpRequest/responseText)
+    pub fn response_text(&self) -> Option<String> {
+        let response = js!(return @{self}.responseText;);
+        match response {
+            Value::Null => None,
+            Value::String(resp) => Some(resp),
+            _ => unreachable!(),
+        }
+    }
+
+    /// Returns an unsigned short with the status of the response of the request.
+    ///
+    /// [(JavaScript docs)](https://developer.mozilla.org/en-US/docs/Web/API/XMLHttpRequest/status)
+    pub fn status(&self) -> u16 {
+        js!(return @{self}.status;).try_into().unwrap()
+    }
+
+    /// Open connection with given method (ie GET or POST), and the url to hit
+    ///
+    /// [(JavaScript docs)](https://developer.mozilla.org/en-US/docs/Web/API/XMLHttpRequest/open)
+    pub fn open(&self, method: &str, url: &str) {
+        js! {
+            @{self}.open(@{method}, @{url}, true);
+        };
+    }
+
+    /// Send request on an open connection with no data
+    ///
+    /// [(JavaScript docs)](https://developer.mozilla.org/en-US/docs/Web/API/XMLHttpRequest/send)
+    pub fn send(&self) {
+        js! {
+            @{self}.send();
+        };
+    }
+
+    /// Send request on an open connection with string body
+    ///
+    /// [(JavaScript docs)](https://developer.mozilla.org/en-US/docs/Web/API/XMLHttpRequest/send)
+    pub fn send_with_string(&self, body: &str) {
+        js! {
+            @{self}.send(@{body});
+        };
+    }
+
+    /// Send request on an open connection with a byte array body
+    ///
+    /// [(JavaScript docs)](https://developer.mozilla.org/en-US/docs/Web/API/XMLHttpRequest/send)
+    pub fn send_with_bytes(&self, body: &[u8]) {
+        js! {
+            @{self}.send(@{UnsafeTypedArray(body)});
+        };
+    }
+
+    /// Aborts the request if it has already been sent.
+    /// When a request is aborted, its [ready_state](struct.XMLHttpRequest.html#method.ready_state) is changed to [Done](enum.ReadyState.html#variant.Done)
+    /// and the [status](struct.XMLHttpRequest.html#method.status) code is set to
+    /// [Unsent](enum.ReadyState.html#variant.Unsent).
+    /// 
+    /// [(JavaScript docs)](https://developer.mozilla.org/en-US/docs/Web/API/XMLHttpRequest/abort)
+    pub fn abort(&self) {
+        js! {
+            @{self}.abort();
+        };
+    }
+}


### PR DESCRIPTION
At first, I just made a http_get function on the window that would make a get request and callback with the response, but I figured I might as well just give it a little more substance and create the whole object.

I think that it would be more cost-effective to couple these together so that there is less crossing of he wasm-js boundary and you'd only need to call one function. However, I saw somewhere that this library was trying to maintain low-level access so I figured this would be more flexible for a user. In comparison to the cost of a network request, the cost of crossing the boundary should be negligible.