### PR TITLE
Add TextAreaElement with value getter/setter

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -161,6 +161,7 @@ pub mod web {
     pub mod html_element {
         pub use webapi::html_elements::ImageElement;
         pub use webapi::html_elements::InputElement;
+        pub use webapi::html_elements::TextAreaElement;
     }
 
     /// A module containing JavaScript DOM events.

--- a/src/webapi/html_elements/mod.rs
+++ b/src/webapi/html_elements/mod.rs
@@ -1,5 +1,7 @@
 mod image;
 mod input;
+mod textarea;
 
 pub use self::image::ImageElement;
 pub use self::input::InputElement;
+pub use self::textarea::TextAreaElement;

--- a/src/webapi/html_elements/textarea.rs
+++ b/src/webapi/html_elements/textarea.rs
@@ -1,0 +1,43 @@
+use webcore::value::Reference;
+use webcore::try_from::TryInto;
+use webapi::event_target::{IEventTarget, EventTarget};
+use webapi::node::{INode, Node};
+use webapi::element::{IElement, Element};
+use webapi::html_element::{IHtmlElement, HtmlElement};
+
+/// The HTML <textarea> element represents a multi-line plain-text editing control.
+///
+/// [(JavaScript docs)](https://developer.mozilla.org/en/docs/Web/HTML/Element/textarea)
+pub struct TextAreaElement( Reference );
+
+impl IEventTarget for TextAreaElement {}
+impl INode for TextAreaElement {}
+impl IElement for TextAreaElement {}
+impl IHtmlElement for TextAreaElement {}
+
+reference_boilerplate! {
+    TextAreaElement,
+    instanceof HTMLTextAreaElement
+    convertible to EventTarget
+    convertible to Node
+    convertible to Element
+    convertible to HtmlElement
+}
+
+impl TextAreaElement {
+    /// The value of the control.
+    #[inline]
+    pub fn value( &self ) -> String {
+        js! (
+            return @{self}.value;
+        ).try_into().unwrap()
+    }
+
+    /// Sets the value of the control.
+    #[inline]
+    pub fn set_value( &self, value: &str ) {
+        js! { @(no_return)
+            @{self}.value = @{value};
+        }
+    }
+}


### PR DESCRIPTION
I want to use textareas like inputs, but now I have to use `js!` workaround only to get or set value to a textarea element.
Also this PR helps me to implement https://github.com/DenisKolodin/yew/pull/82
