### PR TITLE
WIP: HTML media events and elements

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -160,9 +160,14 @@ pub mod web {
 
     /// A module containing HTML DOM elements.
     pub mod html_element {
+        pub use webapi::html_elements::AudioElement;
+        pub use webapi::html_elements::HtmlMediaElement;
+        pub use webapi::html_elements::IHtmlMediaElement;
         pub use webapi::html_elements::ImageElement;
         pub use webapi::html_elements::InputElement;
+        pub use webapi::html_elements::ReadyState;
         pub use webapi::html_elements::TextAreaElement;
+        pub use webapi::html_elements::VideoElement;
     }
 
     /// A module containing JavaScript DOM events.

--- a/src/webapi/event.rs
+++ b/src/webapi/event.rs
@@ -1221,6 +1221,133 @@ impl ConcreteEvent for PopStateEvent {
     const EVENT_TYPE: &'static str = "popstate";
 }
 
+/// Declare a list of simple media events, preserving documentation. There are
+/// a lot of these, and almost none of them have an interesting payload.
+macro_rules! media_events {
+    ( $( $( #[$attr:meta] )* event $name:ident $evt_type:expr ; )* ) => {
+        $(
+            $(#[$attr])*
+            pub struct $name( Reference );
+
+            impl IEvent for $name {}
+            impl ConcreteEvent for $name {
+                const EVENT_TYPE: &'static str = $evt_type;
+            }
+
+            reference_boilerplate! {
+                $name,
+                instanceof Event
+                convertible to Event
+            }
+        )*
+    }
+}
+
+media_events! {
+    /// The `CanPlayEvent` is fired when the user agent can play a media
+    /// element, but may not have enough data to support continuous playback.
+    ///
+    /// [(JavaScript docs)](https://developer.mozilla.org/en-US/docs/Web/Events/canplay)
+    event CanPlayEvent "canplay";
+
+    /// The `CanPlayThroughEvent` is fired when the user agent can play a media
+    /// element, and should have enough data to play through at the current
+    /// loading rate.
+    ///
+    /// [(JavaScript docs)](https://developer.mozilla.org/en-US/docs/Web/Events/canplaythrough)
+    event CanPlayThroughEvent "canplaythrough";
+
+    /// The `DurationChangeEvent` is fired when the `duration` attribute of a
+    /// media element is updated.
+    ///
+    /// [(JavaScript docs)](https://developer.mozilla.org/en-US/docs/Web/Events/durationchange)
+    event DurationChangeEvent "durationchange";
+
+    /// The `EmptiedEvent` is fired when a media element becomes empty, for
+    /// example, during a reload.
+    ///
+    /// [(JavaScript docs)](https://developer.mozilla.org/en-US/docs/Web/Events/emptied)
+    event EmptiedEvent "emptied";
+
+    /// The `EndedEvent` is fired when media playback has reached the end or
+    /// run out of data.
+    ///
+    /// [(JavaScript docs)](https://developer.mozilla.org/en-US/docs/Web/Events/ended)
+    event EndedEvent "ended";
+
+    /// The `LoadedDataEvent` is fired when the first frame of the media has
+    /// been loaded.
+    ///
+    /// [(JavaScript docs)](https://developer.mozilla.org/en-US/docs/Web/Events/loadeddata)
+    event LoadedDataEvent "loadeddata";
+
+    /// The `LoadedMetadataEvent` is fired when the first frame of the media has
+    /// been loaded.
+    ///
+    /// [(JavaScript docs)](https://developer.mozilla.org/en-US/docs/Web/Events/loadedmetadata)
+    event LoadedMetadataEvent "loadedmetadata";
+
+    /// The `PauseEvent` is fired when media playback is paused.
+    ///
+    /// [(JavaScript docs)](https://developer.mozilla.org/en-US/docs/Web/Events/pause)
+    event PauseEvent "pause";
+
+    /// The `PlayEvent` is fired when playback is triggered.
+    ///
+    /// [(JavaScript docs)](https://developer.mozilla.org/en-US/docs/Web/Events/play)
+    event PlayEvent "play";
+
+    /// The `PlayingEvent` is fired when playback actually begins.
+    ///
+    /// [(JavaScript docs)](https://developer.mozilla.org/en-US/docs/Web/Events/playing)
+    event PlayingEvent "playing";
+
+    /// The `RateChangeEvent` is fired when playback rate changes.
+    ///
+    /// [(JavaScript docs)](https://developer.mozilla.org/en-US/docs/Web/Events/ratechange)
+    event RateChangeEvent "ratechange";
+
+    /// The `SeekedEvent` is fired when a media seek finishes.
+    ///
+    /// [(JavaScript docs)](https://developer.mozilla.org/en-US/docs/Web/Events/seeked)
+    event SeekedEvent "seekedevent";
+
+    /// The `SeekingEvent` is fired when a media seek begins.
+    ///
+    /// [(JavaScript docs)](https://developer.mozilla.org/en-US/docs/Web/Events/seeking)
+    event SeekingEvent "seeking";
+
+    /// The `StalledEvent` is fired when playback stops because data is
+    /// unavailable.
+    ///
+    /// [(JavaScript docs)](https://developer.mozilla.org/en-US/docs/Web/Events/stalled)
+    event StalledEvent "stalled";
+
+    /// The `SuspendEvent` is fired when media loading is suspended, possibly
+    /// because it has finished or because the media has been paused.
+    ///
+    /// [(JavaScript docs)](https://developer.mozilla.org/en-US/docs/Web/Events/suspend)
+    event SuspendEvent "suspend";
+
+    /// The `TimeUpdateEvent` is fired when the `currentTime` attribute of a
+    /// media element changes.
+    ///
+    /// [(JavaScript docs)](https://developer.mozilla.org/en-US/docs/Web/Events/timeupdate)
+    event TimeUpdateEvent "timeupdate";
+
+    /// The `VolumeChangeEvent` is fired when a media element's volume is
+    /// changed, or when the mute state changes.
+    ///
+    /// [(JavaScript docs)](https://developer.mozilla.org/en-US/docs/Web/Events/volumechange)
+    event VolumeChangeEvent "volumechange";
+
+    /// The `WaitingEvent` is sent when an operation is delayed because it is
+    /// waiting on another operation.
+    ///
+    /// [(JavaScript docs)](https://developer.mozilla.org/en-US/docs/Web/Events/waiting)
+    event WaitingEvent "waiting";
+}
+
 #[cfg(all(test, feature = "web_test"))]
 mod tests {
     use super::*;

--- a/src/webapi/html_elements/media.rs
+++ b/src/webapi/html_elements/media.rs
@@ -1,0 +1,183 @@
+use webcore::value::Reference;
+use webcore::try_from::TryInto;
+use webapi::event_target::{IEventTarget, EventTarget};
+use webapi::node::{INode, Node};
+use webapi::element::{IElement, Element};
+use webapi::html_element::{IHtmlElement, HtmlElement};
+
+/// The readiness state of a media element.
+///
+/// [(JavaScript docs)](https://developer.mozilla.org/en-US/docs/Web/API/HTMLMediaElement/readyState)
+#[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
+pub enum ReadyState {
+    /// No information is available about this media resource yet.
+    HaveNothing,
+    /// Metadata for the media has been loaded, and seeking is possible.
+    HaveMetadata,
+    /// Data is available for the current playback position, but not for more
+    /// than one frame.
+    HaveCurrentData,
+    /// Data for several frames after the current position is available, but
+    /// not enough to allow consistent playback.
+    HaveFutureData,
+    /// Enough data is available to permit uninterrupted playback at the current
+    /// download rate.
+    HaveEnoughData,
+}
+
+/// The `IHtmlElement` interface represents an `<audio>` or `<video>` element.
+///
+/// [(JavaScript docs)](https://developer.mozilla.org/en-US/docs/Web/API/HTMLMediaElement)
+pub trait IHtmlMediaElement: IHtmlElement {
+
+    /// Should the media start playing as soon as enough data has been loaded
+    /// that is should be able play without interruption?
+    #[inline]
+    fn autoplay( &self ) -> bool {
+        js! (
+            return @{self.as_ref()}.autoplay;
+        ).try_into().unwrap()
+    }
+
+    /// Sets whether autoplay is enabled.
+    #[inline]
+    fn set_autoplay( &self, value: bool ) {
+        js! { @(no_return)
+            @{self.as_ref()}.autoplay = @{value};
+        }
+    }
+
+    /// Should media-playing controls be displayed for this element?
+    #[inline]
+    fn controls( &self ) -> bool {
+        js! (
+            return @{self.as_ref()}.controls;
+        ).try_into().unwrap()
+    }
+
+    /// Sets whether media-playing controls should be displayed.
+    #[inline]
+    fn set_controls( &self, value: bool ) {
+        js! { @(no_return)
+            @{self.as_ref()}.controls = @{value};
+        }
+    }
+
+    /// The current playback time, in seconds.
+    #[inline]
+    fn current_time( &self ) -> f64 {
+        js! (
+            return @{self.as_ref()}.currentTime;
+        ).try_into().unwrap()
+    }
+
+    /// Set current playback time to the specified value, in seconds. This will
+    /// seek playback.
+    #[inline]
+    fn set_current_time( &self, value: f64 ) {
+        js! { @(no_return)
+            @{self.as_ref()}.currentTime = @{value};
+        }
+    }
+
+    /// Is this media element currently paused?
+    #[inline]
+    fn paused( &self ) -> bool {
+        js! (
+            return @{self.as_ref()}.paused;
+        ).try_into().unwrap()
+    }
+
+    /// Is this media element currently paused?
+    fn ready_state( &self ) -> ReadyState {
+        let ready_state = js! (
+            return @{self.as_ref()}.ready_state;
+        ).try_into().unwrap();
+        match ready_state {
+            0 => ReadyState::HaveNothing,
+            1 => ReadyState::HaveMetadata,
+            2 => ReadyState::HaveCurrentData,
+            3 => ReadyState::HaveFutureData,
+            4 => ReadyState::HaveEnoughData,
+            _ => unreachable!( "Unexpected value of MediaElement::ready_state: {}", ready_state )
+        }
+    }
+
+    /// Pauses the media playback.
+    fn pause( &self ) {
+        js! { @(no_return)
+            @{self.as_ref()}.pause();
+        }
+    }
+
+    /// Starts the media playback.
+    fn play( &self ) {
+        js! { @(no_return)
+            @{self.as_ref()}.play();
+        }
+    }
+}
+
+/// A reference to a JavaScript object which implements the
+/// [IMediaHtmlElement](trait.IMediaHtmlElement.html) interface.
+///
+/// [(JavaScript docs)](https://developer.mozilla.org/en-US/docs/Web/API/HTMLMediaElement)
+pub struct HtmlMediaElement(Reference);
+
+impl IEventTarget for HtmlMediaElement {}
+impl INode for HtmlMediaElement {}
+impl IElement for HtmlMediaElement {}
+impl IHtmlElement for HtmlMediaElement {}
+
+reference_boilerplate! {
+    HtmlMediaElement,
+    instanceof HTMLMediaElement
+    convertible to EventTarget
+    convertible to Node
+    convertible to Element
+    convertible to HtmlElement
+}
+
+/// The HTML `<audio>` element represents an audio stream with optional player
+/// controls.
+///
+/// [(JavaScript docs)](https://developer.mozilla.org/en-US/docs/Web/API/HTMLAudioElement)
+pub struct AudioElement(Reference);
+
+impl IEventTarget for AudioElement {}
+impl INode for AudioElement {}
+impl IElement for AudioElement {}
+impl IHtmlElement for AudioElement {}
+impl IHtmlMediaElement for AudioElement {}
+
+reference_boilerplate! {
+    AudioElement,
+    instanceof HTMLAudioElement
+    convertible to EventTarget
+    convertible to Node
+    convertible to Element
+    convertible to HtmlElement
+    convertible to HtmlMediaElement
+}
+
+/// The HTML `<video>` element represents a video stream with optional player
+/// controls.
+///
+/// [(JavaScript docs)](https://developer.mozilla.org/en-US/docs/Web/API/HTMLVideoElement)
+pub struct VideoElement(Reference);
+
+impl IEventTarget for VideoElement {}
+impl INode for VideoElement {}
+impl IElement for VideoElement {}
+impl IHtmlElement for VideoElement {}
+impl IHtmlMediaElement for VideoElement {}
+
+reference_boilerplate! {
+    VideoElement,
+    instanceof HTMLVideoElement
+    convertible to EventTarget
+    convertible to Node
+    convertible to Element
+    convertible to HtmlElement
+    convertible to HtmlMediaElement
+}

--- a/src/webapi/html_elements/mod.rs
+++ b/src/webapi/html_elements/mod.rs
@@ -1,7 +1,9 @@
 mod image;
 mod input;
+mod media;
 mod textarea;
 
 pub use self::image::ImageElement;
 pub use self::input::InputElement;
+pub use self::media::{AudioElement, HtmlMediaElement, IHtmlMediaElement, ReadyState, VideoElement};
 pub use self::textarea::TextAreaElement;


### PR DESCRIPTION
Not yet ready to merge! I'm working on implementing #62. However, I would be very interested in feedback about how I can make this code fit nicely into stdweb without causing any headaches for the maintainers.

Progress:

- [x] HTML media events. These are pretty complete at this point (except for some proprietary Mozilla extensions). There are a large number of these events, and they all have nearly-identical implementations, so I decided to implement them using a macro.
- [x] A basic `IHTMLMediaElement` trait. This is shared between `<audio>` and `<video>`. I've implemented a handful of the most important attributes and methods, but there are plenty more that could be added. Right now, I put this in the `html_elements` namespace, along with a supporting `ReadyState` type, but maybe this should live elsewhere?
- [x] `AudioElement` and `VideoElement` structs. These are just implementations of `IHTMLMediaElement`, and they shoudn't need any logic of their own, as far as I know.
- [ ] Tests. I haven't quite figured out `stdweb` testing yet, but I need to look at it before I go further.
- [ ] A real-world app. I want to actually try to use this from Rust.
- [ ] More `IHTMLMediaElement` attributes and methods?

Anyway, thank you for your encouragement, and please let me know if you have any suggestions!