### PR TITLE
Adding in MutationObserver

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -149,7 +149,7 @@ pub mod web {
     pub use webapi::history::History;
     pub use webapi::web_socket::{WebSocket, SocketCloseCode};
     pub use webapi::rendering_context::{RenderingContext, CanvasRenderingContext2d};
-    pub use webapi::mutation_observer::{MutationObserver, MutationObserverInit, MutationRecord};
+    pub use webapi::mutation_observer::{IMutationObserver, MutationObserver, MutationObserverHandle, MutationObserverInit, MutationRecord};
 
 
     /// A module containing XmlHttpRequest and its XhrReadyState

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -149,6 +149,7 @@ pub mod web {
     pub use webapi::history::History;
     pub use webapi::web_socket::{WebSocket, SocketCloseCode};
     pub use webapi::rendering_context::{RenderingContext, CanvasRenderingContext2d};
+    pub use webapi::mutation_observer::{MutationObserver, MutationObserverInit, MutationRecord};
 
 
     /// A module containing XmlHttpRequest and its XhrReadyState

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -149,7 +149,7 @@ pub mod web {
     pub use webapi::history::History;
     pub use webapi::web_socket::{WebSocket, SocketCloseCode};
     pub use webapi::rendering_context::{RenderingContext, CanvasRenderingContext2d};
-    pub use webapi::mutation_observer::{IMutationObserver, MutationObserver, MutationObserverHandle, MutationObserverInit, MutationRecord};
+    pub use webapi::mutation_observer::{MutationObserver, MutationObserverHandle, MutationObserverInit, MutationRecord};
 
 
     /// A module containing XmlHttpRequest and its XhrReadyState

--- a/src/webapi/mod.rs
+++ b/src/webapi/mod.rs
@@ -27,3 +27,4 @@ pub mod xml_http_request;
 pub mod history;
 pub mod web_socket;
 pub mod rendering_context;
+pub mod mutation_observer;

--- a/src/webapi/mutation_observer.rs
+++ b/src/webapi/mutation_observer.rs
@@ -230,19 +230,17 @@ mod tests {
 
     #[test]
     fn test_observe() {
-        let observer = MutationObserver::new( |records| {
-
-        } );
+        let observer = MutationObserver::new( |_| {} );
 
         // TODO replace with document.body
-        observer.observe( &document(),  MutationObserverInit {
+        observer.observe( &document(),  &MutationObserverInit {
             child_list: true,
             attributes: false,
             character_data: true,
             subtree: true,
             attribute_old_value: false,
             character_data_old_value: false,
-            attribute_filter: &[ "foo", "bar", "qux" ],
+            attribute_filter: Some( &[ "foo", "bar", "qux" ] ),
         } );
     }
 }

--- a/src/webapi/mutation_observer.rs
+++ b/src/webapi/mutation_observer.rs
@@ -179,7 +179,7 @@ impl Drop for MutationObserverHandle {
         self.disconnect();
 
         js! { @(no_return)
-            @{self.callback_reference}.drop();
+            @{&self.callback_reference}.drop();
         }
     }
 }

--- a/src/webapi/mutation_observer.rs
+++ b/src/webapi/mutation_observer.rs
@@ -99,7 +99,7 @@ impl MutationObserver {
     /// [`character_data`](struct.MutationObserverInit.html#structfield.character_data) must be `true`.
     ///
     /// [(JavaScript docs)](https://developer.mozilla.org/en-US/docs/Web/API/MutationObserver#observe())
-    pub fn observe< T: INode >( &self, target: &T, options: &MutationObserverInit ) {
+    pub fn observe< T: INode >( &self, target: &T, options: MutationObserverInit ) {
         let attribute_filter: Value = match options.attribute_filter {
             Some( a ) => a.into(),
             // This must compile to JavaScript `undefined`, NOT `null`
@@ -244,7 +244,7 @@ mod tests {
         let observer = MutationObserver::new( |_, _| {} );
 
         // TODO replace with document.body
-        observer.observe( &document(),  &MutationObserverInit {
+        observer.observe( &document(),  MutationObserverInit {
             child_list: true,
             attributes: true,
             character_data: true,

--- a/src/webapi/mutation_observer.rs
+++ b/src/webapi/mutation_observer.rs
@@ -325,7 +325,5 @@ mod tests {
             character_data_old_value: true,
             attribute_filter: Some( &[ "foo", "bar", "qux" ] ),
         } );
-
-        observer.disconnect();
     }
 }

--- a/src/webapi/mutation_observer.rs
+++ b/src/webapi/mutation_observer.rs
@@ -241,7 +241,7 @@ mod tests {
 
     #[ test ]
     fn test_observe() {
-        let observer = MutationObserver::new( |_| {} );
+        let observer = MutationObserver::new( |_, _| {} );
 
         // TODO replace with document.body
         observer.observe( &document(),  &MutationObserverInit {

--- a/src/webapi/mutation_observer.rs
+++ b/src/webapi/mutation_observer.rs
@@ -20,7 +20,7 @@ reference_boilerplate! {
 /// Only used with the [`MutationObserver::observe`](struct.MutationObserver.html#method.observe) method.
 ///
 /// [(JavaScript docs)](https://developer.mozilla.org/en-US/docs/Web/API/MutationObserver#MutationObserverInit)
-#[derive( Debug, Clone )]
+#[ derive( Debug, Clone ) ]
 pub struct MutationObserverInit< 'a > {
     /// If `true` it will observe all inserts and removals of the target's children (including text nodes).
     ///
@@ -146,7 +146,7 @@ impl MutationObserver {
 /// It is passed to [`MutationObserver`](struct.MutationObserver.html)'s callback.
 ///
 /// [(JavaScript docs)](https://developer.mozilla.org/en-US/docs/Web/API/MutationRecord)
-#[derive( Debug, Clone )]
+#[ derive( Debug, Clone ) ]
 pub enum MutationRecord {
     /// One of the target's attributes was changed.
     Attribute {
@@ -236,7 +236,7 @@ mod tests {
     use super::*;
     use webapi::document::document;
 
-    #[test]
+    #[ test ]
     fn test_observe() {
         let observer = MutationObserver::new( |_| {} );
 

--- a/src/webapi/mutation_observer.rs
+++ b/src/webapi/mutation_observer.rs
@@ -22,33 +22,33 @@ reference_boilerplate! {
 /// [(JavaScript docs)](https://developer.mozilla.org/en-US/docs/Web/API/MutationObserver#MutationObserverInit)
 #[derive(Debug, Clone)]
 pub struct MutationObserverInit<'a> {
-    /// If set to `true` it will observe all inserts and removals of the target's children (including text nodes).
+    /// If `true` it will observe all inserts and removals of the target's children (including text nodes).
     ///
     /// This is **not** recursive, it will only observe immediate children
-    /// (unless [`subtree`](struct.MutationObserverInit.html#structfield.subtree) is set to `true` in which case it will
+    /// (unless [`subtree`](struct.MutationObserverInit.html#structfield.subtree) is `true` in which case it will
     /// observe **all** children and sub-children recursively).
     pub child_list: bool,
 
-    /// If set to `true` it will observe all changes to the target's attributes.
+    /// If `true` it will observe all changes to the target's attributes.
     pub attributes: bool,
 
-    /// If set to `true` it will observe all changes to the `CharacterData`'s data.
+    /// If `true` it will observe all changes to the `CharacterData`'s data.
     pub character_data: bool,
 
-    /// If set to `true` it will observe all changes to the target, the target's children, and the target's sub-children.
+    /// If `true` it will observe all changes to the target, the target's children, and the target's sub-children.
     ///
     /// This is recursive, so it causes **all** children and sub-children to be observed.
     pub subtree: bool,
 
-    /// If set to `true` it will store the target's old attribute value in [`old_value`](enum.MutationRecord.html#variant.Attribute).
+    /// If `true` it will store the target's old attribute value in [`old_value`](enum.MutationRecord.html#variant.Attribute).
     pub attribute_old_value: bool,
 
-    /// If set to `true` it will store the `CharacterData`'s old data in [`old_data`](enum.MutationRecord.html#variant.CharacterData).
+    /// If `true` it will store the `CharacterData`'s old data in [`old_data`](enum.MutationRecord.html#variant.CharacterData).
     pub character_data_old_value: bool,
 
-    /// If set, it will only observe the specified attributes.
+    /// If `Some` it will only observe the specified attributes. The attributes should be specified without a namespace.
     ///
-    /// The attributes should be specified without a namespace.
+    /// If `None` it will observe all attributes.
     pub attribute_filter: Option< &'a [ &'a str ] >,
 }
 
@@ -84,7 +84,7 @@ impl MutationObserver {
     /// * At least one of
     /// [`child_list`](struct.MutationObserverInit.html#structfield.child_list),
     /// [`attributes`](struct.MutationObserverInit.html#structfield.attributes), or
-    /// [`character_data`](struct.MutationObserverInit.html#structfield.character_data) must be set to `true`.
+    /// [`character_data`](struct.MutationObserverInit.html#structfield.character_data) must be `true`.
     ///
     /// * If [`attribute_old_value`](struct.MutationObserverInit.html#structfield.attribute_old_value) is `true`, then
     /// [`attributes`](struct.MutationObserverInit.html#structfield.attributes) must be `true`.

--- a/src/webapi/mutation_observer.rs
+++ b/src/webapi/mutation_observer.rs
@@ -1,0 +1,135 @@
+use webcore::value::{Reference, Value, ConversionError};
+use webapi::node_list::NodeList;
+use webcore::try_from::{TryFrom, TryInto};
+use webapi::node::{INode, Node};
+
+
+/// `MutationObserver` provides developers with a way to react to changes in a DOM.
+///
+/// [(JavaScript docs)](https://developer.mozilla.org/en-US/docs/Web/API/MutationObserver)
+pub struct MutationObserver( Reference );
+
+reference_boilerplate! {
+    MutationObserver,
+    instanceof MutationObserver
+}
+
+
+pub struct MutationObserverInit {
+    child_list: bool,
+    attribute: bool,
+    character_data: bool,
+    subtree: bool,
+    attribute_old_value: bool,
+    character_data_old_value: bool,
+    attribute_filter: Vec< String >,
+}
+
+
+impl MutationObserver {
+    // TODO implement second argument for callback
+    fn new< F >( callback: F ) -> Self
+        where F: FnMut( Vec< MutationRecord > ) + 'static {
+        js! (
+            return new MutationObserver( @{callback} );
+        ).try_into().unwrap()
+    }
+
+    fn observe< T: INode >( &self, target: &T, options: MutationObserverInit ) {
+        js! { @(no_return)
+            @{self.as_ref()}.observe( @{target.as_ref()}, {
+                childList: @{options.child_list},
+                attributes: @{options.attribute},
+                characterData: @{options.character_data},
+                subtree: @{options.subtree},
+                attributeOldValue: @{options.attribute_old_value},
+                characterDataOldValue: @{options.character_data_old_value},
+                attributeFilter: @{options.attribute_filter.from()}
+            } );
+        }
+    }
+
+    fn disconnect( &self ) {
+        js! { @(no_return)
+            @{self.as_ref()}.disconnect();
+        }
+    }
+
+    fn take_records( &self ) -> Vec< MutationRecord > {
+        js!(
+            return @{self.as_ref()}.takeRecords();
+        ).try_into().unwrap()
+    }
+}
+
+
+#[derive(Debug)]
+pub enum MutationRecord {
+    Attribute {
+        target: Node,
+        attribute_name: Option< String >,
+        attribute_namespace: Option< String >,
+        old_value: Option< String >,
+    },
+
+    CharacterData {
+        target: Node,
+        old_value: Option< String >,
+    },
+
+    ChildList {
+        target: Node,
+        added_nodes: NodeList,
+        removed_nodes: NodeList,
+        previous_sibling: Option< Node >,
+        next_sibling: Option< Node >,
+    },
+}
+
+
+impl TryFrom< Value > for MutationRecord {
+    type Error = ConversionError;
+
+    fn try_from( v: Value ) -> Result< Self, Self::Error > {
+        match v {
+            Value::Reference( ref r ) => {
+                // TODO propagate errors with ?
+                let _type: String = js!( @{r}.type ).try_into().unwrap();
+
+                // TODO propagate errors with ?
+                let target: Node = js!( @{r}.target ).try_into().unwrap();
+
+                match _type.as_str() {
+                    "attributes" => Ok( MutationRecord::Attribute {
+                        target: target,
+                        attribute_name: js!( @{r}.attributeName ).try_into()?,
+                        attribute_namespace: js!( @{r}.attributeNamespace ).try_into()?,
+                        old_value: js!( @{r}.oldValue ).try_into()?,
+                    } ),
+
+                    "characterData" => Ok( MutationRecord::CharacterData {
+                        target: target,
+                        old_value: js!( @{r}.oldValue ).try_into()?,
+                    } ),
+
+                    "childList" => Ok( MutationRecord::ChildList {
+                        target: target,
+
+                        // TODO propagate errors with ?
+                        added_nodes: js!( @{r}.addedNodes ).try_into().unwrap(),
+
+                        // TODO propagate errors with ?
+                        removed_nodes: js!( @{r}.removedNodes ).try_into().unwrap(),
+
+                        previous_sibling: js!( @{r}.previousSibling ).try_into()?,
+
+                        next_sibling: js!( @{r}.nextSibling ).try_into()?,
+                    } ),
+
+                    other => Err( ConversionError::Custom( format!( "Unknown MutationRecord type: {:?}", other ) ) )
+                }
+            },
+            other => Err( ConversionError::Custom( format!( "Expected MutationRecord but got: {:?}", other ) ) )
+        }
+    }
+}

--- a/src/webapi/mutation_observer.rs
+++ b/src/webapi/mutation_observer.rs
@@ -243,11 +243,11 @@ mod tests {
         // TODO replace with document.body
         observer.observe( &document(),  &MutationObserverInit {
             child_list: true,
-            attributes: false,
+            attributes: true,
             character_data: true,
             subtree: true,
-            attribute_old_value: false,
-            character_data_old_value: false,
+            attribute_old_value: true,
+            character_data_old_value: true,
             attribute_filter: Some( &[ "foo", "bar", "qux" ] ),
         } );
     }

--- a/src/webapi/mutation_observer.rs
+++ b/src/webapi/mutation_observer.rs
@@ -76,16 +76,24 @@ impl MutationObserver {
     ///
     /// Multiple different targets can be observed simultaneously (with the same or different `options`).
     ///
-    /// If you call `observe` on the same target multiple times, only the first call will have an effect,
-    /// the rest of the calls are ignored.
+    /// If you call `observe` on the same `target` multiple times, it will replace the old `options`
+    /// with the new `options`. It will **not** call the callback multiple times for the same `target`.
     ///
     /// # Panics
     ///
-    /// At least one of
+    /// * At least one of
     /// [`child_list`](struct.MutationObserverInit.html#structfield.child_list),
     /// [`attributes`](struct.MutationObserverInit.html#structfield.attributes), or
     /// [`character_data`](struct.MutationObserverInit.html#structfield.character_data) must be set to `true`.
-    /// Otherwise "An invalid or illegal string was specified" panic occurs.
+    ///
+    /// * If [`attribute_old_value`](struct.MutationObserverInit.html#structfield.attribute_old_value) is `true`, then
+    /// [`attributes`](struct.MutationObserverInit.html#structfield.attributes) must be `true`.
+    ///
+    /// * If [`attribute_filter`](struct.MutationObserverInit.html#structfield.attribute_filter) is `Some`, then
+    /// [`attributes`](struct.MutationObserverInit.html#structfield.attributes) must be `true`.
+    ///
+    /// * If [`character_data_old_value`](struct.MutationObserverInit.html#structfield.character_data_old_value) is `true`, then
+    /// [`character_data`](struct.MutationObserverInit.html#structfield.character_data) must be `true`.
     ///
     /// [(JavaScript docs)](https://developer.mozilla.org/en-US/docs/Web/API/MutationObserver#observe())
     pub fn observe< T: INode >( &self, target: &T, options: &MutationObserverInit ) {

--- a/src/webapi/mutation_observer.rs
+++ b/src/webapi/mutation_observer.rs
@@ -20,8 +20,8 @@ reference_boilerplate! {
 /// Only used with the [`MutationObserver::observe`](struct.MutationObserver.html#method.observe) method.
 ///
 /// [(JavaScript docs)](https://developer.mozilla.org/en-US/docs/Web/API/MutationObserver#MutationObserverInit)
-#[derive(Debug, Clone)]
-pub struct MutationObserverInit<'a> {
+#[derive( Debug, Clone )]
+pub struct MutationObserverInit< 'a > {
     /// If `true` it will observe all inserts and removals of the target's children (including text nodes).
     ///
     /// This is **not** recursive, it will only observe immediate children
@@ -146,7 +146,7 @@ impl MutationObserver {
 /// It is passed to [`MutationObserver`](struct.MutationObserver.html)'s callback.
 ///
 /// [(JavaScript docs)](https://developer.mozilla.org/en-US/docs/Web/API/MutationRecord)
-#[derive(Debug, Clone)]
+#[derive( Debug, Clone )]
 pub enum MutationRecord {
     /// One of the target's attributes was changed.
     Attribute {
@@ -231,7 +231,7 @@ impl TryFrom< Value > for MutationRecord {
 }
 
 
-#[cfg(all(test, feature = "web_test"))]
+#[ cfg( all( test, feature = "web_test" ) ) ]
 mod tests {
     use super::*;
     use webapi::document::document;

--- a/src/webapi/mutation_observer.rs
+++ b/src/webapi/mutation_observer.rs
@@ -201,10 +201,10 @@ impl TryFrom< Value > for MutationRecord {
     fn try_from( v: Value ) -> Result< Self, Self::Error > {
         match v {
             Value::Reference( ref r ) => {
-                let _type: String = js!( return @{r}.type; ).try_into()?;
+                let kind: String = js!( return @{r}.type; ).try_into()?;
                 let target: Node = js!( return @{r}.target; ).try_into()?;
 
-                match _type.as_str() {
+                match kind.as_str() {
                     "attributes" => Ok( MutationRecord::Attribute {
                         target: target,
                         name: js!( return @{r}.attributeName; ).try_into()?,

--- a/src/webapi/mutation_observer.rs
+++ b/src/webapi/mutation_observer.rs
@@ -201,28 +201,28 @@ impl TryFrom< Value > for MutationRecord {
     fn try_from( v: Value ) -> Result< Self, Self::Error > {
         match v {
             Value::Reference( ref r ) => {
-                let _type: String = js!( return @{r}.type ).try_into()?;
-                let target: Node = js!( return @{r}.target ).try_into()?;
+                let _type: String = js!( return @{r}.type; ).try_into()?;
+                let target: Node = js!( return @{r}.target; ).try_into()?;
 
                 match _type.as_str() {
                     "attributes" => Ok( MutationRecord::Attribute {
                         target: target,
-                        name: js!( return @{r}.attributeName ).try_into()?,
-                        namespace: js!( return @{r}.attributeNamespace ).try_into()?,
-                        old_value: js!( return @{r}.oldValue ).try_into()?,
+                        name: js!( return @{r}.attributeName; ).try_into()?,
+                        namespace: js!( return @{r}.attributeNamespace; ).try_into()?,
+                        old_value: js!( return @{r}.oldValue; ).try_into()?,
                     } ),
 
                     "characterData" => Ok( MutationRecord::CharacterData {
                         target: target,
-                        old_data: js!( return @{r}.oldValue ).try_into()?,
+                        old_data: js!( return @{r}.oldValue; ).try_into()?,
                     } ),
 
                     "childList" => Ok( MutationRecord::ChildList {
                         target: target,
-                        inserted_nodes: js!( return @{r}.addedNodes ).try_into()?,
-                        removed_nodes: js!( return @{r}.removedNodes ).try_into()?,
-                        previous_sibling: js!( return @{r}.previousSibling ).try_into()?,
-                        next_sibling: js!( return @{r}.nextSibling ).try_into()?,
+                        inserted_nodes: js!( return @{r}.addedNodes; ).try_into()?,
+                        removed_nodes: js!( return @{r}.removedNodes; ).try_into()?,
+                        previous_sibling: js!( return @{r}.previousSibling; ).try_into()?,
+                        next_sibling: js!( return @{r}.nextSibling; ).try_into()?,
                     } ),
 
                     other => Err( ConversionError::Custom( format!( "Unknown MutationRecord type: {:?}", other ) ) ),

--- a/src/webapi/mutation_observer.rs
+++ b/src/webapi/mutation_observer.rs
@@ -100,11 +100,10 @@ impl MutationObserver {
     ///
     /// [(JavaScript docs)](https://developer.mozilla.org/en-US/docs/Web/API/MutationObserver#observe())
     pub fn observe< T: INode >( &self, target: &T, options: MutationObserverInit ) {
-        let attribute_filter: Value = match options.attribute_filter {
-            Some( a ) => a.into(),
+        let attribute_filter = options.attribute_filter
+            .map( |val| val.into() )
             // This must compile to JavaScript `undefined`, NOT `null`
-            None => Value::Undefined,
-        };
+            .unwrap_or( Value::Undefined );
 
         js! { @(no_return)
             @{self.as_ref()}.observe( @{target.as_ref()}, {

--- a/src/webapi/mutation_observer.rs
+++ b/src/webapi/mutation_observer.rs
@@ -15,14 +15,14 @@ reference_boilerplate! {
 }
 
 
-pub struct MutationObserverInit {
+pub struct MutationObserverInit<'a> {
     child_list: bool,
     attribute: bool,
     character_data: bool,
     subtree: bool,
     attribute_old_value: bool,
     character_data_old_value: bool,
-    attribute_filter: Vec< String >,
+    attribute_filter: &'a [ &'a str ],
 }
 
 
@@ -74,7 +74,7 @@ pub enum MutationRecord {
 
     CharacterData {
         target: Node,
-        old_value: Option< String >,
+        old_data: Option< String >,
     },
 
     ChildList {
@@ -109,7 +109,7 @@ impl TryFrom< Value > for MutationRecord {
 
                     "characterData" => Ok( MutationRecord::CharacterData {
                         target: target,
-                        old_value: js!( @{r}.oldValue ).try_into()?,
+                        old_data: js!( @{r}.oldValue ).try_into()?,
                     } ),
 
                     "childList" => Ok( MutationRecord::ChildList {

--- a/src/webapi/mutation_observer.rs
+++ b/src/webapi/mutation_observer.rs
@@ -250,5 +250,7 @@ mod tests {
             character_data_old_value: true,
             attribute_filter: Some( &[ "foo", "bar", "qux" ] ),
         } );
+
+        observer.disconnect();
     }
 }


### PR DESCRIPTION
Fixes #85 

@koute Requesting a review on this, since I'm not 100% sure how all these abstractions work yet.

Also, I haven't tested this yet, and it's missing unit tests. I can't really add in unit tests, because the unit tests need to be async.

Also, I tried to keep the API the same as the web, but I did significantly change `MutationRecord`, because that makes the API **much** safer and more Rust-y.