### PR TITLE
Implement Error and DOMException. Add patterns for error handling.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -157,7 +157,17 @@ pub mod web {
     }
     /// A module containing error types.
     pub mod error {
-        pub use webapi::node::NotFoundError;
+        pub use webapi::dom_exception::{
+            IDomException,
+            DomException,
+            ConcreteException,
+            HierarchyRequestError,
+            InvalidAccessError,
+            NotFoundError,
+            SecurityError,
+            SyntaxError,
+        };
+        pub use webapi::error::{IError, Error};        
     }
 
     /// A module containing HTML DOM elements.

--- a/src/webapi/dom_exception.rs
+++ b/src/webapi/dom_exception.rs
@@ -1,0 +1,155 @@
+use webcore::value::Reference;
+use webapi::error::{IError, Error};
+
+/// The `IDomException` interface represents an abnormal event which occurs as the result of
+/// calling a web API.
+///
+/// [(JavaScript docs)](https://developer.mozilla.org/en-US/docs/Web/API/DOMException)
+pub trait IDomException: IError {}
+
+/// A reference to a JavaScript `DOMException` object.
+///
+/// [(JavaScript docs)](https://developer.mozilla.org/en-US/docs/Web/API/DOMException)
+pub struct DomException( Reference );
+
+// DOMException specification:
+// https://heycam.github.io/webidl/#idl-DOMException
+
+impl IError for DomException {}
+impl IDomException for DomException {}
+
+reference_boilerplate! {
+    DomException,
+    instanceof DOMException
+    convertible to Error
+}
+error_boilerplate! { DomException }
+
+/// A trait representing a concrete DOMException.
+pub trait ConcreteException: IDomException {
+    /// A string representing the error type.
+    ///
+    /// [(JavaScript docs)](https://developer.mozilla.org/en-US/docs/Web/API/DOMException/name)
+    const ERROR_NAME: &'static str;
+}
+
+// To safely cast from a reference to a specific DomException, we must check that the object is an
+// instance of DOMException, and that the error name matches.
+impl<T: ConcreteException + ::webcore::value::FromReferenceUnchecked> ::webcore::value::FromReference for T {
+    #[inline]
+    fn from_reference( reference: Reference ) -> Option< Self > {
+        if instanceof!( reference, DOMException ) &&
+            js!( return @{reference.clone()}.name; ) == Self::ERROR_NAME {
+            unsafe {
+                Some( Self::from_reference_unchecked( reference ) )
+            }
+        } else {
+            None
+        }
+    }
+}
+
+/// Occurs when an operation would result in an incorrect node tree.
+pub struct HierarchyRequestError( Reference );
+
+impl IError for HierarchyRequestError {}
+impl IDomException for HierarchyRequestError {}
+impl ConcreteException for HierarchyRequestError {
+    const ERROR_NAME: &'static str = "HierarchyRequestError";
+}
+
+reference_boilerplate! {
+    HierarchyRequestError,
+    convertible to Error    
+    convertible to DomException
+}
+error_boilerplate! { HierarchyRequestError }
+
+/// Occurs when an object does not support an operation or argument.
+pub struct InvalidAccessError( Reference );
+
+impl IError for InvalidAccessError {}
+impl IDomException for InvalidAccessError {}
+impl ConcreteException for InvalidAccessError {
+    const ERROR_NAME: &'static str = "InvalidAccessError";
+}
+
+reference_boilerplate! {
+    InvalidAccessError,
+    convertible to Error    
+    convertible to DomException
+}
+error_boilerplate! { InvalidAccessError }
+
+/// Occurs when the specified object cannot be found.
+pub struct NotFoundError( Reference );
+
+impl IError for NotFoundError {}
+impl IDomException for NotFoundError {}
+impl ConcreteException for NotFoundError {
+    const ERROR_NAME: &'static str = "NotFoundError";
+}
+
+reference_boilerplate! {
+    NotFoundError,
+    convertible to Error    
+    convertible to DomException
+}
+error_boilerplate! { NotFoundError }
+
+/// Occurs when the requested operation is insecure.
+pub struct SecurityError( Reference );
+
+impl IError for SecurityError {}
+impl IDomException for SecurityError {}
+impl ConcreteException for SecurityError {
+    const ERROR_NAME: &'static str = "SecurityError";
+}
+
+reference_boilerplate! {
+    SecurityError,
+    convertible to Error    
+    convertible to DomException
+}
+error_boilerplate! { SecurityError }
+
+/// Occurs when an argument does not match the expected pattern.
+pub struct SyntaxError( Reference );
+
+impl IError for SyntaxError {}
+impl IDomException for SyntaxError {}
+impl ConcreteException for SyntaxError {
+    const ERROR_NAME: &'static str = "SyntaxError";
+}
+
+reference_boilerplate! {
+    SyntaxError,
+    convertible to Error    
+    convertible to DomException
+}
+error_boilerplate! { SyntaxError }
+
+#[cfg(all(test, feature = "web_test"))]
+mod test {
+    use super::*;
+    use webcore::try_from::TryInto;
+
+    fn new_dom_exception(message: &str, name: &str) -> DomException {
+        js!(
+            return new DOMException(@{message}, @{name});
+        ).try_into().unwrap()
+    }
+
+    #[test]
+    fn test_error() {
+        // Successful downcast.
+        let err: DomException = new_dom_exception("foo", HierarchyRequestError::ERROR_NAME);
+        let err: HierarchyRequestError = err.try_into().expect("Expected HierarchyRequestError");
+        assert_eq!(err.name(), HierarchyRequestError::ERROR_NAME);
+
+        // Failed downcast.
+        let err: DomException = new_dom_exception("foo", SecurityError::ERROR_NAME);
+        let err: Result<SyntaxError, _> = err.try_into();
+        assert!(err.is_err());
+    }
+}

--- a/src/webapi/error.rs
+++ b/src/webapi/error.rs
@@ -1,0 +1,67 @@
+use webcore::value::{Value, Reference};
+use webcore::try_from::{TryFrom, TryInto};
+
+/// Represents the JavaScript `Error` interface. An `Error` is thrown whenever a run-time error
+/// occurs.
+///
+/// [(JavaScript docs)](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error)
+pub trait IError: AsRef< Reference > + TryFrom< Value > {
+    /// Returns a human-readable description of the error.
+    ///
+    /// [(JavaScript docs)](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error/message)
+    #[inline]
+    fn message( &self ) -> String {
+        js!(
+            return @{self.as_ref()}.message;
+        ).try_into().unwrap()
+    }
+
+    /// Returns a name specifiying the type of error.
+    ///
+    /// [(JavaScript docs)](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error/name)
+    #[inline]
+    fn name( &self ) -> String {
+        js!(
+            return @{self.as_ref()}.name;
+        ).try_into().unwrap()
+    }
+}
+
+/// A reference to a JavaScript `Error` object. An `Error` is thrown whenever a run-time error
+/// occurs.
+///
+/// [(JavaScript docs)](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error)
+pub struct Error( Reference );
+
+// Error specification:
+// https://www.ecma-international.org/ecma-262/6.0/#sec-error-objects
+
+impl IError for Error {}
+
+reference_boilerplate! {
+    Error,
+    instanceof Error
+}
+error_boilerplate! { Error }
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn test_error() {
+        use ::std::fmt::Write;
+
+        let error: Error = js!(
+           return new Error("foo");
+        ).try_into().unwrap();
+
+        assert_eq!(error.name(), "Error");
+        assert_eq!(error.message(), "foo");
+        
+        let mut text = String::new();
+        write!(&mut text, "{}", error).unwrap();
+        assert_eq!(&text, "Error: foo");
+        assert_eq!(::std::error::Error::description(&error), "Error");
+    }
+}

--- a/src/webapi/mod.rs
+++ b/src/webapi/mod.rs
@@ -27,3 +27,5 @@ pub mod xml_http_request;
 pub mod history;
 pub mod web_socket;
 pub mod rendering_context;
+pub mod error;
+pub mod dom_exception;

--- a/src/webapi/node.rs
+++ b/src/webapi/node.rs
@@ -1,28 +1,12 @@
-use std::fmt;
-use std::error;
 use std::mem;
 
-use webcore::value::{Reference, FromReference};
-use webcore::try_from::TryInto;
+use webcore::value::{Reference, FromReference, Value};
+use webcore::try_from::{TryFrom, TryInto};
 use webapi::document::Document;
+use webapi::dom_exception::{HierarchyRequestError, NotFoundError};
 use webapi::element::Element;
 use webapi::event_target::{IEventTarget, EventTarget};
 use webapi::node_list::NodeList;
-
-/// A structure denoting that the specified DOM [Node](trait.INode.html) was not found.
-#[derive(Debug)]
-pub struct NotFoundError( String );
-impl error::Error for NotFoundError {
-    fn description( &self ) -> &str {
-        self.0.as_str()
-    }
-}
-
-impl fmt::Display for NotFoundError {
-    fn fmt( &self, formatter: &mut fmt::Formatter ) -> fmt::Result {
-        write!( formatter, "{}", self.0 )
-    }
-}
 
 /// An enum which determines whenever the DOM [Node](trait.INode.html)'s children will also be cloned or not.
 ///
@@ -63,26 +47,10 @@ pub trait INode: IEventTarget + FromReference {
     /// Removes a child node from the DOM.
     ///
     /// [(JavaScript docs)](https://developer.mozilla.org/en-US/docs/Web/API/Node/removeChild)
-    fn remove_child< T: INode >( &self, child: &T ) -> Result< (), NotFoundError > {
-        // TODO: Return the removed node.
-        let status = js! {
-            try {
-                @{self.as_ref()}.removeChild( @{child.as_ref()} );
-                return true;
-            } catch( exception ) {
-                if( exception instanceof NotFoundError ) {
-                    return false;
-                } else {
-                    throw exception;
-                }
-            }
-        };
-
-        if status == true {
-            Ok(())
-        } else {
-            Err( NotFoundError( "The node to be removed is not a child of this node.".to_owned() ) )
-        }
+    fn remove_child< T: INode >( &self, child: &T ) -> Result< Node, NotFoundError > {
+        js_try! (
+            return @{self.as_ref()}.removeChild( @{child.as_ref()} );
+        ).unwrap()
     }
 
     /// Returns a duplicate of the node on which this method was called.
@@ -113,19 +81,19 @@ pub trait INode: IEventTarget + FromReference {
     /// Inserts the specified node before the reference node as a child of the current node.
     ///
     /// [(JavaScript docs)](https://developer.mozilla.org/en-US/docs/Web/API/Node/insertBefore)
-    fn insert_before< T: INode, U: INode >( &self, new_node: &T, reference_node: &U ) {
-        js! { @(no_return)
-            @{self.as_ref()}.insertBefore( @{new_node.as_ref()}, @{reference_node.as_ref()} );
-        }
+    fn insert_before< T: INode, U: INode >( &self, new_node: &T, reference_node: &U ) -> Result< Node, InsertNodeError > {
+        js_try! (
+            return @{self.as_ref()}.insertBefore( @{new_node.as_ref()}, @{reference_node.as_ref()} );
+        ).unwrap()
     }
 
     /// Replaces one hild node of the specified node with another.
     ///
     /// [(JavaScript docs)](https://developer.mozilla.org/en-US/docs/Web/API/Node/replaceChild)
-    fn replace_child< T: INode, U: INode >( &self, new_child: &T, old_child: &U ) {
-        js! { @(no_return)
-            @{self.as_ref()}.replaceChild( @{new_child.as_ref()}, @{old_child.as_ref()} );
-        }
+    fn replace_child< T: INode, U: INode >( &self, new_child: &T, old_child: &U ) -> Result< Node, InsertNodeError > {
+        js_try! (
+            return @{self.as_ref()}.replaceChild( @{new_child.as_ref()}, @{old_child.as_ref()} );
+        ).unwrap()
     }
 
     /// Returns the parent of this node in the DOM tree.
@@ -357,6 +325,12 @@ pub trait INode: IEventTarget + FromReference {
     }
 }
 
+/// Errors thrown by `Node` insertion methods.
+error_enum_boilerplate! {
+    InsertNodeError,
+    NotFoundError, HierarchyRequestError
+}
+
 /// A reference to a JavaScript object which implements the [INode](trait.INode.html)
 /// interface.
 ///
@@ -489,10 +463,13 @@ mod tests {
         parent.append_child(&child1);
         parent.append_child(&child2);
 
-        parent.remove_child(&child1).unwrap();
+        let removed = parent.remove_child(&child1).unwrap();
         assert_eq!(parent.first_child().unwrap().as_ref(), child2.as_ref());
-
-        // TODO: assert!(parent.remove_child(&child1).is_err());
+        assert_eq!(removed.as_ref(), child1.as_ref());        
+        match parent.remove_child(&child1) {
+            Err(_) => (),
+            _ => panic!("Expected error")
+        }
 
         parent.remove_child(&child2).unwrap();
         assert!(parent.first_child().is_none())
@@ -544,9 +521,20 @@ mod tests {
         let node = div();
         let child1 = div();
         let child2 = div();
+        let child3 = div();
         node.append_child(&child1);
-        node.insert_before(&child2, &child1);
+        node.insert_before(&child2, &child1).unwrap();
         assert_eq!(node.first_child().unwrap().as_ref(), child2.as_ref());
+
+        match node.insert_before(&child3, &child3) {
+            Err(InsertNodeError::NotFoundError(_)) => (),
+            _ => panic!("Expected NotFoundError")
+        }
+
+        match node.insert_before(&doc_type(), &child1) {
+            Err(InsertNodeError::HierarchyRequestError(_)) => (),
+            _ => panic!("Expected HierarchyRequestError")
+        }
     }
 
     #[test]
@@ -555,9 +543,19 @@ mod tests {
         let child1 = div();
         let child2 = div();
         node.append_child(&child1);
-        node.replace_child(&child2, &child1);
+        node.replace_child(&child2, &child1).unwrap();
         assert_eq!(node.first_child().unwrap().as_ref(), child2.as_ref());
         assert!(child1.parent_node().is_none());
+
+        match node.replace_child(&child2, &child1) {
+            Err(InsertNodeError::NotFoundError(_)) => (),
+            _ => panic!("Expected NotFoundError")
+        }
+
+        match node.replace_child(&doc_type(), &child2) {
+            Err(InsertNodeError::HierarchyRequestError(_)) => (),
+            _ => panic!("Expected HierarchyRequestError")
+        }
     }
 
     #[test]

--- a/src/webapi/web_socket.rs
+++ b/src/webapi/web_socket.rs
@@ -278,6 +278,11 @@ mod tests {
         assert_eq!(&format!("{:?}", SocketCloseCode(1000)), "SocketCloseCode::NORMAL_CLOSURE");
         assert_eq!(&format!("{:?}", SocketCloseCode(3001)), "SocketCloseCode(3001)");
     }
+}
+
+#[cfg(all(test, feature = "web_test"))]
+mod web_tests {
+    use super::*;
 
     #[test]
     fn test_new() {

--- a/src/webcore/macros.rs
+++ b/src/webcore/macros.rs
@@ -676,6 +676,22 @@ macro_rules! reference_boilerplate {
     };
 }
 
+macro_rules! error_boilerplate {
+    ($name:ident) => {
+        impl ::std::fmt::Display for $name {
+            fn fmt(&self, formatter: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
+                write!(formatter, "{}: {}", stringify!($name), self.message())
+            }
+        }
+
+        impl ::std::error::Error for $name {
+            fn description(&self) -> &str {
+                stringify!($name)
+            }
+        }
+    }
+}
+
 macro_rules! instanceof {
     ($value:expr, $kind:ident) => {{
         use $crate::unstable::TryInto;
@@ -708,6 +724,114 @@ macro_rules! newtype_enum {
                     $($value => write!(formatter, "{}::{}", stringify!($name), stringify!($variant)),)*
                     other => write!(formatter, "{}({})", stringify!($name), other)
                 }
+            }
+        }
+    }
+}
+
+/// Embeds JavaScript code into your Rust program similar to the `js!` macro, but
+/// catches errors that may be thrown.
+///
+/// This macro will attempt to coerce the value into the inferred `Result` type.
+/// The success and error types should implement `TryFrom<Value>`.
+///
+/// # Examples
+///
+/// ```
+/// let result: Result<i32, String> = js_try! {
+///     throw "error";
+/// }.unwrap();
+/// assert_eq!(result, Err("error".to_string()));
+/// ```
+macro_rules! js_try {
+    (@(no_return) $($token:tt)*) => {{
+        let result = js! {
+            try {
+                $($token)*
+                return {
+                    success: true
+                };
+            } catch( error ) {
+                return {
+                    error: error,
+                    success: false
+                };
+            }
+        };
+
+        use ::webcore::try_from::TryInto;
+        if js!( return @{result.as_ref()}.success; ) == true {
+            Ok(Ok(()))
+        } else {
+            match js!( return @{result}.error; ).try_into() {
+                Ok(e) => Ok(Err(e)),
+                Err(e) => Err(e),
+            }
+        }
+    }};
+
+    ($($token:tt)*) => {{
+        let result = js! {
+            try {
+                return {
+                    value: function() { $($token)* }(),
+                    success: true
+                };
+            } catch( error ) {
+                return {
+                    error: error,
+                    success: false
+                };
+            }
+        };
+
+        use webcore::try_from::TryInto;
+        if js!( return @{result.as_ref()}.success; ) == true {
+            match js!( return @{result}.value; ).try_into() {
+                Ok(t) => Ok(Ok(t)),
+                Err(e) => Err(e),
+            }
+        } else {
+            match js!( return @{result}.error; ).try_into() {
+                Ok(e) => Ok(Err(e)),
+                Err(e) => Err(e),
+            }
+        }
+    }};
+}
+
+macro_rules! error_enum_boilerplate {
+    ($error_name:ident, $($variant:ident),*) => {
+        #[derive(Debug, Clone)]
+        pub enum $error_name {
+            $($variant($variant)),*
+        }
+
+        impl TryFrom<::webcore::value::Value> for $error_name {
+            type Error = ::webcore::value::ConversionError;
+
+            fn try_from(value: ::webcore::value::Value) -> Result<Self, Self::Error> {
+                $(
+                    if let Ok(v) = $variant::try_from(value.clone()) {
+                        return Ok($error_name::$variant(v));
+                    }
+                )*
+
+                Err(::webcore::value::ConversionError::type_mismatch( &value ))
+            }
+        }
+
+        impl ::std::fmt::Display for $error_name {
+            fn fmt(&self, formatter: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
+                match *self {
+                    $($error_name::$variant( ref r ) => r.fmt(formatter),)*
+                }
+            }
+        }
+
+        impl ::std::error::Error for $error_name {
+            fn description(&self) -> &str {
+                stringify!($error_name)
             }
         }
     }
@@ -747,5 +871,40 @@ mod tests {
             }.replace( " ", "" ),
             "($1).fn(($2));"
         );
+    }
+
+    #[test]
+    fn js_try() {
+        use ::webcore::value::{ConversionError, Value};
+
+        let v: Result<Value, Value> = js_try!( return "test"; ).unwrap();
+        assert_eq!( v, Ok(Value::String("test".to_string())) );
+
+        let v: Result<bool, bool> = js_try!( return true; ).unwrap();
+        assert_eq!( v, Ok(true) );
+
+        let v: Result<bool, bool> = js_try!( throw true; ).unwrap();
+        assert_eq!( v, Err(true) );
+
+        let v: Result<i32, String> = js_try!( throw "error"; ).unwrap();
+        assert_eq!( v, Err("error".to_string()) );
+        
+        let v: Result<(), String> = js_try!( @(no_return) 2+2; ).unwrap();
+        assert_eq!( v, Ok(()) );
+
+        let v: Result<(), f64> = js_try!( @(no_return) throw 3.3; ).unwrap();
+        assert_eq!( v, Err(3.3) );
+
+        let v: Result< Result<i32, i32>, _ > = js_try!( return "f"; );
+        match v {
+            Err(ConversionError::TypeMismatch { actual_type: _ }) => (),
+            _ => panic!("Expected ConversionError::TypeMistmatch, got {:?}", v),
+        }
+
+        let v: Result< Result<i32, i32>, _ > = js_try!( throw "Broken"; );
+        match v {
+            Err(ConversionError::TypeMismatch { actual_type: _ }) => (),
+            _ => panic!("Expected ConversionError::TypeMistmatch, got {:?}", v),
+        }
     }
 }


### PR DESCRIPTION
I've had this floating around on my hard drive for a bit -- there is room for improvement, feedback requested!

Addresses #28. Methods that throw an error were using an ad-hoc `js!` block to catch the error and transfer it back. However, this gets difficult when a method returns multiple error types. This PR adds macros to make error handling more consistent and easy.

- Implement Error and DOMException types.
- Implement a `js_try!` macro that works like `js!`, but also catches errors and convert them to a `Result` type.
  - This macro relies on `TryFrom<Value>` being implemented for both the value and error type.
  - Specifically for `DOMException`, these have the same type in JS, but different names. For the concrete exception types in Rust, `FromReference` and `TryFrom` is implemented to check that the name matches.
  - The implementation of `js_try!` isn't optimal, with lots of calls back and forth to JS. I expect this could be done much better, perhaps by adding serialization support for a Result type. I was more concerned with establishing the pattern of how the errors should be caught on the Rust side; the macro can be improved.
  - Unlike the `js!` macro, `js_try!` does a `try_into` internally.
- For calls that may return several different errors, an enum can be used, and the `error_enum_boilerplate!` macro is used to implement `TryFrom<Value>` for the enum.
  - This will try to convert the value to each variant in sequence.
  - My macro-fu is a little weak, so maybe the syntax for this macro should be different. Even better, I think this could be done as a custom derive if we're okay with that.
- As an example, the `js_try!` macro is used to return errors from these APIs:
  - `Node::replace_child`, `Node::insert_before`
  - `WebSocket::new` and `WebSocket::close_with_status` (thanks @Diggsey!)

Things left for a future PR:
- Backtraces (could be placed in the `IError` trait?).
- Using a crate such as failure.
  - It didn't seem like there was a consensus on this yet.
  - #21 specified that error-chain was too heavy, but failure might be more appropriate. It would allow us to upcast into a unifying Error type. Maybe it's more ergonomic for failing methods to return `Result<_, failure::Error>` instead of defining an enum-per-throwing-function. But I think it's nice to know explicitly what errors a function might throw.
