### PR TITLE
Squelch some unused_parens warnings on nightly

### DIFF
--- a/src/webapi/typed_array.rs
+++ b/src/webapi/typed_array.rs
@@ -27,7 +27,7 @@ macro_rules! arraykind {
                         ".slice( $0, $1 ) );"
                     ),
                     slice_ptr,
-                    (slice_ptr + slice.len() as i32)
+                    slice_ptr + slice.len() as i32
                 );
 
                 let reference = unsafe {

--- a/src/webcore/macros.rs
+++ b/src/webcore/macros.rs
@@ -412,7 +412,7 @@ macro_rules! _js_impl {
 
             $crate::private::noop( &mut memory_required );
 
-            #[allow(unused_unsafe)]
+            #[allow(unused_unsafe, unused_parens)]
             unsafe {
                 _js_impl!(
                     @if no_return in [$($flags)*] {
@@ -579,6 +579,7 @@ macro_rules! __reference_boilerplate {
         }
 
         impl< $($impl_arg)* > Clone for $($kind_arg)* where $($bounds)* {
+            #[allow(unused_parens)]
             #[inline]
             fn clone( &self ) -> Self {
                 call_with_repeated_tail!( ($($kind_arg)*), ((self.0.clone())), foreach ($($impl_arg)*) -> (::std::default::Default::default()) )
@@ -593,6 +594,7 @@ macro_rules! __reference_boilerplate {
         }
 
         impl< $($impl_arg)* > $crate::private::FromReferenceUnchecked for $($kind_arg)* where $($bounds)* {
+            #[allow(unused_parens)]
             #[inline]
             unsafe fn from_reference_unchecked( reference: $crate::Reference ) -> Self {
                 call_with_repeated_tail!( ($($kind_arg)*), (reference), foreach ($($impl_arg)*) -> (::std::default::Default::default()) )

--- a/src/webcore/serialization.rs
+++ b/src/webcore/serialization.rs
@@ -301,7 +301,7 @@ pub fn deserialize_object< R, F: FnOnce( &mut ObjectDeserializer ) -> R >( refer
         var object = Module.STDWEB.acquire_js_reference( $0 );\
         Module.STDWEB.serialize_object( $1, object );",
         reference.as_raw(),
-        (&mut result as *mut _)
+        &mut result as *mut _
     );
 
     assert_eq!( result.tag, Tag::Object );
@@ -363,7 +363,7 @@ pub fn deserialize_array< R, F: FnOnce( &mut ArrayDeserializer ) -> R >( referen
         var array = Module.STDWEB.acquire_js_reference( $0 );\
         Module.STDWEB.serialize_array( $1, array );",
         reference.as_raw(),
-        (&mut result as *mut _)
+        &mut result as *mut _
     );
 
     assert_eq!( result.tag, Tag::Array );


### PR DESCRIPTION
Nightly currently produces a ton of warnings about unused parentheses. Most seem to be false positives from the macro syntax. Added `#[allow(unused_parens)]` to these cases.