### PR TITLE
Expand CanvasRenderingContext API

### DIFF
--- a/src/webapi/rendering_context.rs
+++ b/src/webapi/rendering_context.rs
@@ -39,4 +39,23 @@ impl CanvasRenderingContext2d {
             @{&self.0}.fillRect(@{x}, @{y}, @{width}, @{height});
         }
     }
+
+    /// Draws a text string at the specified coordinates, filling the string's characters 
+    /// with the current foreground color. An optional parameter allows specifying a maximum 
+    /// width for the rendered text, which the user agent will achieve by condensing the 
+    /// text or by using a lower font size.
+    /// 
+    /// [(JavaScript docs)](https://developer.mozilla.org/en-US/docs/Web/API/CanvasRenderingContext2D/fillText)
+    pub fn fill_text(&self, text: &str, x: f64, y: f64, max_width: Option<f64>) {
+        if let Some(max_width) = max_width {
+            js! { @(no_return)
+                @{&self.0}.fillText(@{text}, @{x}, @{y}, @{max_width});
+            }
+        }
+        else {
+            js! { @(no_return)
+                @{&self.0}.fillText(@{text}, @{x}, @{y});
+            }
+        }
+    }
 }


### PR DESCRIPTION
Added the [fillText](https://developer.mozilla.org/en-US/docs/Web/API/CanvasRenderingContext2D/fillText) function from the CanvasRenderingContext2D API