### PR TITLE
Adding in Promises

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,14 +18,15 @@ serde = { version = "1", optional = true }
 serde_json = { version = "1", optional = true }
 clippy = { version = "0.0", optional = true }
 stdweb-derive = { path = "stdweb-derive" }
+futures = { version = "0.1.18", optional = true }
 
 [dev-dependencies]
 serde_json = "1"
 serde_derive = "1"
 
 [features]
-default = ["serde", "serde_json"]
-dev = ["serde", "serde_json", "clippy"]
+default = ["serde", "serde_json", "futures"]
+dev = ["serde", "serde_json", "futures", "clippy"]
 serde-support = ["serde", "serde_json"]
 nightly = []
 web_test = []

--- a/examples/promise/Cargo.toml
+++ b/examples/promise/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "promise"
+version = "0.1.0"
+authors = ["Pauan <pcxunlimited@gmail.com>"]
+
+[dependencies]
+stdweb = { path = "../.." }
+futures = "0.1.18"

--- a/examples/promise/src/main.rs
+++ b/examples/promise/src/main.rs
@@ -5,7 +5,7 @@ extern crate futures;
 use futures::Future;
 use stdweb::unstable::{TryInto};
 use stdweb::web::error::Error;
-use stdweb::{Null, PromiseFuture};
+use stdweb::{Null, Promise, PromiseFuture};
 
 
 fn sleep( ms: u32 ) -> PromiseFuture< Null > {
@@ -77,6 +77,13 @@ impl Future for MyFuture {
 
 fn main() {
     stdweb::initialize();
+
+    let promise: Promise = js!( return Promise.resolve(null); ).try_into().unwrap();
+
+    promise.done( |result: Result< Null, Error >| {
+        log( &format!( "Promise result: {:#?}", result ) );
+        panic!( "Testing panic!" );
+    } );
 
     PromiseFuture::spawn(
         MyFuture::new().map( |x| {

--- a/examples/promise/src/main.rs
+++ b/examples/promise/src/main.rs
@@ -4,6 +4,7 @@ extern crate futures;
 
 use futures::Future;
 use stdweb::unstable::{TryInto};
+use stdweb::web::error::Error;
 use stdweb::{Null, PromiseFuture};
 
 
@@ -26,11 +27,14 @@ fn log( a: &str ) {
 fn main() {
     stdweb::initialize();
 
-    PromiseFuture::spawn_print(
+    PromiseFuture::spawn(
         sleep( 5000 ).inspect( |_| log( "Timeout 1 done!") ).join(
         sleep( 5000 ).inspect( |_| log( "Timeout 2 done!" ) ) )
             .and_then( |_|
-                sleep( 5000 ).inspect( |_| log( "Timeout 3 done!") ) ).map( |_| () )
+                sleep( 5000 ).inspect( |_| log( "Timeout 3 done!") ) )
+            .and_then( |_|
+                futures::future::err( Error::new( "Testing error!" ) ) )
+            .map_err( |e| e.print() )
     );
 
     stdweb::event_loop();

--- a/examples/promise/src/main.rs
+++ b/examples/promise/src/main.rs
@@ -26,7 +26,7 @@ fn log( a: &str ) {
 fn main() {
     stdweb::initialize();
 
-    PromiseFuture::spawn(
+    PromiseFuture::spawn_print(
         sleep( 5000 ).inspect( |_| log( "Timeout 1 done!") ).join(
         sleep( 5000 ).inspect( |_| log( "Timeout 2 done!" ) ) )
             .and_then( |_|

--- a/examples/promise/src/main.rs
+++ b/examples/promise/src/main.rs
@@ -1,3 +1,161 @@
+/*#[cfg(target_arch = "wasm32")]
+#[macro_use]
+extern crate stdweb;
+extern crate futures;
+
+#[cfg(not(target_arch = "wasm32"))]
+extern crate tokio;
+
+use std::rc::Rc;
+use std::cell::RefCell;
+use futures::Future;
+use futures::{Poll, Async};
+use futures::task::{current, Task};
+
+#[cfg(target_arch = "wasm32")]
+fn main() {
+    use stdweb::{PromiseFuture};
+
+    struct TaskA {
+        shared_state: Rc<RefCell<u32>>,
+        task_b: Task,
+    }
+
+    impl Future for TaskA {
+        type Item = ();
+        type Error = ();
+
+        fn poll(&mut self) -> Poll<Self::Item, Self::Error> {
+            js! { console.log("Poll TaskA"); }
+
+            let foo = self.shared_state.borrow_mut();
+
+            js! { console.log(@{format!("TaskA 1: {:#?}", foo)}); }
+
+            self.task_b.notify();
+
+            js! { console.log(@{format!("TaskA 2: {:#?}", foo)}); }
+
+            Ok(Async::NotReady)
+        }
+    }
+
+    struct TaskB {
+        shared_state: Rc<RefCell<u32>>,
+        initialized: bool,
+    }
+
+    impl Future for TaskB {
+        type Item = ();
+        type Error = ();
+
+        fn poll(&mut self) -> Poll<Self::Item, Self::Error> {
+            js! { console.log("Poll TaskB"); }
+
+            if !self.initialized {
+                self.initialized = true;
+
+                let task_b = current();
+
+                let foo = self.shared_state.borrow();
+
+                js! { console.log(@{format!("TaskB 1: {:#?}", foo)}); }
+
+                PromiseFuture::spawn(TaskA {
+                    shared_state: self.shared_state.clone(),
+                    task_b: task_b,
+                });
+            }
+
+            let foo = self.shared_state.borrow();
+
+            js! { console.log(@{format!("TaskB 1: {:#?}", foo)}); }
+
+            Ok(Async::NotReady)
+        }
+    }
+
+    PromiseFuture::spawn(TaskB {
+        shared_state: Rc::new(RefCell::new(0)),
+        initialized: false
+    });
+}
+
+
+#[cfg(not(target_arch = "wasm32"))]
+fn main() {
+    use tokio::executor::current_thread;
+
+    struct TaskA {
+        shared_state: Rc<RefCell<u32>>,
+        task_b: Task,
+    }
+
+    impl Future for TaskA {
+        type Item = ();
+        type Error = ();
+
+        fn poll(&mut self) -> Poll<Self::Item, Self::Error> {
+            println!("Poll TaskA");
+
+            let foo = self.shared_state.borrow_mut();
+
+            println!("TaskA 1: {:#?}", foo);
+
+            self.task_b.notify();
+
+            println!("TaskA 2: {:#?}", foo);
+
+            Ok(Async::NotReady)
+        }
+    }
+
+    struct TaskB {
+        shared_state: Rc<RefCell<u32>>,
+        initialized: bool,
+    }
+
+    impl Future for TaskB {
+        type Item = ();
+        type Error = ();
+
+        fn poll(&mut self) -> Poll<Self::Item, Self::Error> {
+            println!("Poll TaskB");
+
+            if !self.initialized {
+                self.initialized = true;
+
+                let task_b = current();
+
+                let foo = self.shared_state.borrow();
+
+                println!("TaskB 1: {:#?}", foo);
+
+                current_thread::spawn(TaskA {
+                    shared_state: self.shared_state.clone(),
+                    task_b: task_b,
+                });
+            }
+
+            let foo = self.shared_state.borrow();
+
+            println!("TaskB 1: {:#?}", foo);
+
+            Ok(Async::NotReady)
+        }
+    }
+
+    current_thread::run(|_| {
+        current_thread::spawn(TaskB {
+            shared_state: Rc::new(RefCell::new(0)),
+            initialized: false
+        });
+    });
+}*/
+
+
+
+
 #[macro_use]
 extern crate stdweb;
 extern crate futures;
@@ -137,3 +295,4 @@ fn main() {
 
     stdweb::event_loop();
 }
+

--- a/examples/promise/src/main.rs
+++ b/examples/promise/src/main.rs
@@ -16,14 +16,21 @@ fn sleep( ms: u32 ) -> PromiseFuture< Null > {
 }
 
 
+fn log( a: &str ) {
+    js! { @(no_return)
+        console.log( @{a} );
+    }
+}
+
+
 fn main() {
     stdweb::initialize();
 
     PromiseFuture::spawn(
-        sleep( 5000 ).inspect( |_| println!( "Timeout 1 done!") ).join(
-        sleep( 5000 ).inspect( |_| println!( "Timeout 2 done!" ) ) )
+        sleep( 5000 ).inspect( |_| log( "Timeout 1 done!") ).join(
+        sleep( 5000 ).inspect( |_| log( "Timeout 2 done!" ) ) )
             .and_then( |_|
-                sleep( 5000 ).inspect( |_| println!( "Timeout 3 done!") ) ).map( |_| () )
+                sleep( 5000 ).inspect( |_| log( "Timeout 3 done!") ) ).map( |_| () )
     );
 
     stdweb::event_loop();

--- a/examples/promise/src/main.rs
+++ b/examples/promise/src/main.rs
@@ -19,6 +19,26 @@ fn log( a: &str ) {
 }
 
 
+fn test_error_conversion() {
+    let a: PromiseFuture< Null, String > = js!( return Promise.reject( "hi!" ); ).try_into().unwrap();
+
+    PromiseFuture::spawn(
+        a.map( |_| () ).map_err( |x| {
+            log( &format!( "String error: {:#?}", x ) );
+        } )
+    );
+
+    let _a: PromiseFuture< Null, Error > = js!( return Promise.resolve( null ); ).try_into().unwrap();
+    log( "Null works" );
+
+    let _a: PromiseFuture< Null, Error > = js!( return Promise.reject( new Error( "hi!" ) ); ).try_into().unwrap();
+    log( "Error works" );
+
+    //let _a: PromiseFuture< Null, SyntaxError > = js!( return Promise.reject( new Error( "hi!" ) ); ).try_into().unwrap();
+    //log( "Error conversion fails" );
+}
+
+
 fn test_refcell() {
     struct TaskA {
         shared_state: Rc<RefCell<u32>>,
@@ -190,7 +210,7 @@ fn test_notify() {
 
 
 fn test_timeout() {
-    fn sleep( ms: u32 ) -> PromiseFuture< Null > {
+    fn sleep( ms: u32 ) -> PromiseFuture< Null, Error > {
         js!( return new Promise( function ( success, failure ) {
             setTimeout( function () {
                 success( null );
@@ -217,6 +237,7 @@ fn main() {
     test_panic();
     test_notify();
     test_timeout();
+    test_error_conversion();
 
     stdweb::event_loop();
 }

--- a/examples/promise/src/main.rs
+++ b/examples/promise/src/main.rs
@@ -1,21 +1,25 @@
-/*#[cfg(target_arch = "wasm32")]
 #[macro_use]
 extern crate stdweb;
 extern crate futures;
 
-#[cfg(not(target_arch = "wasm32"))]
-extern crate tokio;
-
+use futures::Future;
+use stdweb::unstable::{TryInto};
+use stdweb::web::error::Error;
+use stdweb::{Null, Promise, PromiseFuture};
 use std::rc::Rc;
 use std::cell::RefCell;
-use futures::Future;
 use futures::{Poll, Async};
 use futures::task::{current, Task};
 
-#[cfg(target_arch = "wasm32")]
-fn main() {
-    use stdweb::{PromiseFuture};
 
+fn log( a: &str ) {
+    js! { @(no_return)
+        console.log( @{a} );
+    }
+}
+
+
+fn test_refcell() {
     struct TaskA {
         shared_state: Rc<RefCell<u32>>,
         task_b: Task,
@@ -82,199 +86,99 @@ fn main() {
 }
 
 
-#[cfg(not(target_arch = "wasm32"))]
-fn main() {
-    use tokio::executor::current_thread;
-
-    struct TaskA {
-        shared_state: Rc<RefCell<u32>>,
-        task_b: Task,
-    }
-
-    impl Future for TaskA {
-        type Item = ();
-        type Error = ();
-
-        fn poll(&mut self) -> Poll<Self::Item, Self::Error> {
-            println!("Poll TaskA");
-
-            let foo = self.shared_state.borrow_mut();
-
-            println!("TaskA 1: {:#?}", foo);
-
-            self.task_b.notify();
-
-            println!("TaskA 2: {:#?}", foo);
-
-            Ok(Async::NotReady)
-        }
-    }
-
-    struct TaskB {
-        shared_state: Rc<RefCell<u32>>,
-        initialized: bool,
-    }
-
-    impl Future for TaskB {
-        type Item = ();
-        type Error = ();
-
-        fn poll(&mut self) -> Poll<Self::Item, Self::Error> {
-            println!("Poll TaskB");
-
-            if !self.initialized {
-                self.initialized = true;
-
-                let task_b = current();
-
-                let foo = self.shared_state.borrow();
-
-                println!("TaskB 1: {:#?}", foo);
-
-                current_thread::spawn(TaskA {
-                    shared_state: self.shared_state.clone(),
-                    task_b: task_b,
-                });
-            }
-
-            let foo = self.shared_state.borrow();
-
-            println!("TaskB 1: {:#?}", foo);
-
-            Ok(Async::NotReady)
-        }
-    }
-
-    current_thread::run(|_| {
-        current_thread::spawn(TaskB {
-            shared_state: Rc::new(RefCell::new(0)),
-            initialized: false
-        });
-    });
-}*/
-
-
-
-
-#[macro_use]
-extern crate stdweb;
-extern crate futures;
-
-use futures::Future;
-use stdweb::unstable::{TryInto};
-use stdweb::web::error::Error;
-use stdweb::{Null, Promise, PromiseFuture};
-
-
-fn sleep( ms: u32 ) -> PromiseFuture< Null > {
-    js!( return new Promise( function ( success, failure ) {
-        setTimeout( function () {
-            success( null );
-        }, @{ms} );
-    } ); ).try_into().unwrap()
-}
-
-
-fn log( a: &str ) {
-    js! { @(no_return)
-        console.log( @{a} );
-    }
-}
-
-
-struct MyFuture {
-    polls: u32,
-    count: u32,
-    done: bool,
-    receiver: futures::unsync::oneshot::Receiver< () >,
-}
-
-impl MyFuture {
-    fn new( count: u32 ) -> Self {
-        let ( sender, receiver ) = futures::unsync::oneshot::channel();
-
-        let callback = || {
-            log( "setTimeout done" );
-
-            log( &format!("Sending {:#?}", sender.send( () ) ) );
-        };
-
-        log( "setTimeout started" );
-
-        js! { @(no_return)
-            setTimeout( function () {
-                @{stdweb::Once( callback )}();
-            }, 1000 );
-        }
-
-        Self {
-            polls: 0,
-            count: count,
-            done: false,
-            receiver,
-        }
-    }
-}
-
-impl Future for MyFuture {
-    type Item = u32;
-    type Error = ();
-
-    fn poll( &mut self ) -> futures::Poll< Self::Item, Self::Error > {
-        self.polls += 1;
-
-        if !self.done {
-            match self.receiver.poll() {
-                Ok( futures::Async::Ready( () ) ) => self.done = true,
-
-                Ok( futures::Async::NotReady ) => {},
-
-                Err( _ ) => self.done = true,
-            }
-        }
-
-        if self.done {
-            if self.count == 0 {
-                Ok( futures::Async::Ready( self.polls ) )
-
-            } else {
-                self.count -= 1;
-
-                let task = futures::task::current();
-                task.notify();
-                task.notify();
-                task.notify();
-                task.notify();
-                task.notify();
-                task.notify();
-                task.notify();
-                task.notify();
-                task.notify();
-                task.notify();
-                task.notify();
-                task.notify();
-                task.notify();
-                task.notify();
-
-                Ok( futures::Async::NotReady )
-            }
-
-        } else {
-            Ok( futures::Async::NotReady )
-        }
-    }
-}
-
-
-fn main() {
-    stdweb::initialize();
-
+fn test_panic() {
     let promise: Promise = js!( return Promise.resolve(null); ).try_into().unwrap();
 
     promise.done( |result: Result< Null, Error >| {
         log( &format!( "Promise result: {:#?}", result ) );
         panic!( "Testing panic!" );
     } );
+}
+
+
+fn test_notify() {
+    struct MyFuture {
+        polls: u32,
+        count: u32,
+        done: bool,
+        receiver: futures::unsync::oneshot::Receiver< () >,
+    }
+
+    impl MyFuture {
+        fn new( count: u32 ) -> Self {
+            let ( sender, receiver ) = futures::unsync::oneshot::channel();
+
+            let callback = || {
+                log( "setTimeout done" );
+
+                log( &format!("Sending {:#?}", sender.send( () ) ) );
+            };
+
+            log( "setTimeout started" );
+
+            js! { @(no_return)
+                setTimeout( function () {
+                    @{stdweb::Once( callback )}();
+                }, 1000 );
+            }
+
+            Self {
+                polls: 0,
+                count: count,
+                done: false,
+                receiver,
+            }
+        }
+    }
+
+    impl Future for MyFuture {
+        type Item = u32;
+        type Error = ();
+
+        fn poll( &mut self ) -> futures::Poll< Self::Item, Self::Error > {
+            self.polls += 1;
+
+            if !self.done {
+                match self.receiver.poll() {
+                    Ok( futures::Async::Ready( () ) ) => self.done = true,
+
+                    Ok( futures::Async::NotReady ) => {},
+
+                    Err( _ ) => self.done = true,
+                }
+            }
+
+            if self.done {
+                if self.count == 0 {
+                    Ok( futures::Async::Ready( self.polls ) )
+
+                } else {
+                    self.count -= 1;
+
+                    let task = futures::task::current();
+                    task.notify();
+                    task.notify();
+                    task.notify();
+                    task.notify();
+                    task.notify();
+                    task.notify();
+                    task.notify();
+                    task.notify();
+                    task.notify();
+                    task.notify();
+                    task.notify();
+                    task.notify();
+                    task.notify();
+                    task.notify();
+
+                    Ok( futures::Async::NotReady )
+                }
+
+            } else {
+                Ok( futures::Async::NotReady )
+            }
+        }
+    }
 
     PromiseFuture::spawn(
         MyFuture::new( 5 ).map( |x| {
@@ -282,6 +186,17 @@ fn main() {
             assert_eq!( x, 7 );
         } )
     );
+}
+
+
+fn test_timeout() {
+    fn sleep( ms: u32 ) -> PromiseFuture< Null > {
+        js!( return new Promise( function ( success, failure ) {
+            setTimeout( function () {
+                success( null );
+            }, @{ms} );
+        } ); ).try_into().unwrap()
+    }
 
     PromiseFuture::spawn(
         sleep( 2000 ).inspect( |_| log( "Timeout 1 done!") ).join(
@@ -292,6 +207,16 @@ fn main() {
                 futures::future::err( Error::new( "Testing error!" ) ) )
             .map_err( |e| e.print() )
     );
+}
+
+
+fn main() {
+    stdweb::initialize();
+
+    test_refcell();
+    test_panic();
+    test_notify();
+    test_timeout();
 
     stdweb::event_loop();
 }

--- a/examples/promise/src/main.rs
+++ b/examples/promise/src/main.rs
@@ -1,0 +1,30 @@
+#[macro_use]
+extern crate stdweb;
+extern crate futures;
+
+use futures::Future;
+use stdweb::unstable::{TryInto};
+use stdweb::{Null, PromiseFuture};
+
+
+fn sleep( ms: u32 ) -> PromiseFuture< Null > {
+    js!( return new Promise( function ( success, failure ) {
+        setTimeout( function () {
+            success( null );
+        }, @{ms} );
+    } ); ).try_into().unwrap()
+}
+
+
+fn main() {
+    stdweb::initialize();
+
+    PromiseFuture::spawn(
+        sleep( 5000 ).inspect( |_| println!( "Timeout 1 done!") ).join(
+        sleep( 5000 ).inspect( |_| println!( "Timeout 2 done!" ) ) )
+            .and_then( |_|
+                sleep( 5000 ).inspect( |_| println!( "Timeout 3 done!") ) ).map( |_| () )
+    );
+
+    stdweb::event_loop();
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -94,6 +94,9 @@ extern crate stdweb_internal_macros;
 #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
 pub use stdweb_internal_macros::js_export;
 
+#[cfg(any(test, feature = "futures"))]
+extern crate futures;
+
 #[macro_use]
 extern crate stdweb_derive;
 
@@ -127,6 +130,8 @@ pub use webcore::once::Once;
 pub use webcore::instance_of::InstanceOf;
 pub use webcore::reference_type::ReferenceType;
 pub use webcore::serialization::JsSerialize;
+
+pub use webcore::promise::PromiseFuture;
 
 #[cfg(feature = "serde")]
 /// A module with serde-related APIs.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -131,7 +131,7 @@ pub use webcore::instance_of::InstanceOf;
 pub use webcore::reference_type::ReferenceType;
 pub use webcore::serialization::JsSerialize;
 
-pub use webcore::promise::PromiseFuture;
+pub use webcore::promise::{Promise, PromiseFuture};
 
 #[cfg(feature = "serde")]
 /// A module with serde-related APIs.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -94,7 +94,7 @@ extern crate stdweb_internal_macros;
 #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
 pub use stdweb_internal_macros::js_export;
 
-#[cfg(any(test, feature = "futures"))]
+#[cfg(feature = "futures")]
 extern crate futures;
 
 #[macro_use]
@@ -131,7 +131,10 @@ pub use webcore::instance_of::InstanceOf;
 pub use webcore::reference_type::ReferenceType;
 pub use webcore::serialization::JsSerialize;
 
-pub use webcore::promise::{Promise, PromiseFuture};
+pub use webcore::promise::Promise;
+
+#[cfg(feature = "futures")]
+pub use webcore::promise_future::PromiseFuture;
 
 #[cfg(feature = "serde")]
 /// A module with serde-related APIs.

--- a/src/webapi/error.rs
+++ b/src/webapi/error.rs
@@ -37,7 +37,9 @@ pub trait IError: ReferenceType {
 pub struct Error( Reference );
 
 impl Error {
+    /// Creates a new `Error` with the specified `description`.
     ///
+    /// [(JavaScript docs)](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error)
     #[inline]
     pub fn new( description: &str ) -> Self {
         js!( return new Error( @{description} ); ).try_into().unwrap()

--- a/src/webapi/error.rs
+++ b/src/webapi/error.rs
@@ -44,6 +44,16 @@ impl Error {
     pub fn new( description: &str ) -> Self {
         js!( return new Error( @{description} ); ).try_into().unwrap()
     }
+
+    /// Prints the `Error` to the console (this prints the error's description and also its stack trace).
+    ///
+    /// [(JavaScript docs)](https://developer.mozilla.org/en-US/docs/Web/API/Console/error)
+    #[inline]
+    pub fn print( &self ) {
+        js! { @(no_return)
+            console.error( @{self} );
+        }
+    }
 }
 
 // Error specification:

--- a/src/webapi/error.rs
+++ b/src/webapi/error.rs
@@ -36,6 +36,13 @@ pub trait IError: ReferenceType {
 #[reference(instance_of = "Error")]
 pub struct Error( Reference );
 
+impl Error {
+    #[inline]
+    pub fn new( description: &str ) -> Self {
+        js!( return new Error( @{description} ); ).try_into().unwrap()
+    }
+}
+
 // Error specification:
 // https://www.ecma-international.org/ecma-262/6.0/#sec-error-objects
 

--- a/src/webapi/error.rs
+++ b/src/webapi/error.rs
@@ -37,6 +37,7 @@ pub trait IError: ReferenceType {
 pub struct Error( Reference );
 
 impl Error {
+    ///
     #[inline]
     pub fn new( description: &str ) -> Self {
         js!( return new Error( @{description} ); ).try_into().unwrap()

--- a/src/webcore/mod.rs
+++ b/src/webcore/mod.rs
@@ -15,6 +15,7 @@ pub mod unsafe_typed_array;
 pub mod once;
 pub mod instance_of;
 pub mod reference_type;
+pub mod promise;
 
 #[cfg(feature = "nightly")]
 pub mod void {

--- a/src/webcore/mod.rs
+++ b/src/webcore/mod.rs
@@ -16,6 +16,11 @@ pub mod once;
 pub mod instance_of;
 pub mod reference_type;
 pub mod promise;
+
+#[cfg(feature = "futures")]
+pub mod promise_future;
+
+#[cfg(feature = "futures")]
 pub mod promise_executor;
 
 #[cfg(feature = "nightly")]

--- a/src/webcore/mod.rs
+++ b/src/webcore/mod.rs
@@ -16,6 +16,7 @@ pub mod once;
 pub mod instance_of;
 pub mod reference_type;
 pub mod promise;
+pub mod promise_executor;
 
 #[cfg(feature = "nightly")]
 pub mod void {

--- a/src/webcore/promise.rs
+++ b/src/webcore/promise.rs
@@ -157,7 +157,6 @@ pub struct PromiseFuture< A > {
     phantom: PhantomData< A >,
 }
 
-
 impl PromiseFuture< () > {
     /// Asynchronously runs the [`Future`](https://docs.rs/futures/0.1.18/futures/future/trait.Future.html) and immediately returns. This does not block the current thread.
     ///
@@ -187,14 +186,6 @@ impl PromiseFuture< () > {
         } ) );
     }
 }
-
-/*impl< A > PromiseFuture< A > {
-    pub fn new< B >( callback: B ) -> Self
-        where B: FnOnce( FnOnce( A ), FnOnce( JSError ) ) {
-        js!( return new Promise( @{Once( callback )} ); ).try_from().unwrap()
-    }
-}*/
-
 
 impl< A > std::fmt::Debug for PromiseFuture< A > {
     fn fmt( &self, formatter: &mut std::fmt::Formatter ) -> std::fmt::Result {

--- a/src/webcore/promise.rs
+++ b/src/webcore/promise.rs
@@ -173,9 +173,10 @@ impl PromiseFuture< () > {
     ///
     /// ```rust
     /// fn main() {
-    ///     create_some_future()
-    ///         .inspect(|x| println!("Future finished: {:#?}", x))
-    ///         .spawn()
+    ///     PromiseFuture::spawn(
+    ///         create_some_future()
+    ///             .inspect(|x| println!("Future finished: {:#?}", x))
+    ///     )
     /// }
     /// ```
     pub fn spawn< B >( future: B ) where

--- a/src/webcore/promise.rs
+++ b/src/webcore/promise.rs
@@ -1,0 +1,79 @@
+use std;
+use std::marker::PhantomData;
+use {Value, Once};
+use unstable::{TryInto, TryFrom};
+use webcore::value::ConversionError;
+use web::error::Error as JSError;
+use std::error::Error;
+use futures::{future, Future, Poll};
+use futures::sync::oneshot::channel;
+
+
+// TODO split this into Promise and PromiseFuture
+pub struct PromiseFuture< A > {
+    promise: Value,
+    future: Box< Future< Item = A, Error = JSError > >,
+    phantom: PhantomData< A >,
+}
+
+
+impl< A > std::fmt::Debug for PromiseFuture< A > {
+    fn fmt( &self, formatter: &mut std::fmt::Formatter ) -> std::fmt::Result {
+        write!( formatter, "PromiseFuture {:?}", self.promise )
+    }
+}
+
+
+impl< A > Future for PromiseFuture< A > {
+    type Item = A;
+    type Error = JSError;
+
+    fn poll (&mut self ) -> Poll<Self::Item, Self::Error> {
+        self.future.poll()
+    }
+}
+
+
+// TODO this should probably check instanceof Promise
+impl< A: TryFrom< Value > > TryFrom< Value > for PromiseFuture< A > where A: 'static, A::Error: Error {
+    type Error = ConversionError;
+
+    fn try_from( v: Value ) -> Result< Self, Self::Error > {
+        match v {
+            Value::Reference( ref r ) => {
+                let ( sender, receiver ) = channel();
+
+                let callback = |value: Value, success: bool| {
+                    let value: Result< A, JSError > = if success {
+                        let value: Result< A, A::Error > = value.try_into();
+                        value.map_err( |e| JSError::new( e.description() ) )
+                    } else {
+                        let value: Result< JSError, ConversionError > = value.try_into();
+                        value.map_err( |e| JSError::new( e.description() ) ).and_then( Err )
+                    };
+
+                    // TODO is this correct ?
+                    match sender.send( value ) {
+                        Ok( _ ) => {},
+                        Err( _ ) => {},
+                    };
+                };
+
+                Ok( PromiseFuture {
+                    promise: js! {
+                        var callback = @{Once( callback )};
+
+                        return @{r}.then( function (value) {
+                            callback( value, true );
+                        }, function (value) {
+                            callback( value, false );
+                        } );
+                    },
+                    future: Box::new( receiver.map_err( |x| JSError::new( x.description() ) ).and_then( future::result ) ),
+                    phantom: PhantomData,
+                } )
+            },
+            other => Err( ConversionError::Custom( format!( "Expected Promise but got: {:?}", other ) ) ),
+        }
+    }
+}

--- a/src/webcore/promise.rs
+++ b/src/webcore/promise.rs
@@ -15,6 +15,7 @@ use webcore::promise_executor::spawn;
 /// In most situations you shouldn't use this, use [`PromiseFuture`](struct.PromiseFuture.html) instead.
 ///
 /// [(JavaScript docs)](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise)
+// https://www.ecma-international.org/ecma-262/6.0/#sec-promise-objects
 pub struct Promise( Reference );
 
 reference_boilerplate! {
@@ -53,6 +54,9 @@ impl Promise {
     /// ```
     ///
     /// [(JavaScript docs)](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise/resolve)
+    // https://www.ecma-international.org/ecma-262/6.0/#sec-promise.resolve
+    // https://www.ecma-international.org/ecma-262/6.0/#sec-promise-resolve-functions
+    // https://www.ecma-international.org/ecma-262/6.0/#sec-promiseresolvethenablejob
     pub fn promisify( input: Value ) -> Promise {
         js!( return Promise.resolve( @{input} ); ).try_into().unwrap()
     }
@@ -79,6 +83,7 @@ impl Promise {
     /// ```
     ///
     /// [(JavaScript docs)](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise/then)
+    // https://www.ecma-international.org/ecma-262/6.0/#sec-performpromisethen
     pub fn done< A, B >( &self, callback: B )
         where A: TryFrom< Value >,
               A::Error: std::error::Error,

--- a/src/webcore/promise.rs
+++ b/src/webcore/promise.rs
@@ -28,7 +28,7 @@ impl< A > Future for PromiseFuture< A > {
     type Item = A;
     type Error = JSError;
 
-    fn poll (&mut self ) -> Poll<Self::Item, Self::Error> {
+    fn poll (&mut self ) -> Poll< Self::Item, Self::Error > {
         self.future.poll()
     }
 }

--- a/src/webcore/promise.rs
+++ b/src/webcore/promise.rs
@@ -113,9 +113,9 @@ impl Promise {
             var callback = @{Once( callback )};
 
             // TODO don't swallow any errors thrown inside callback
-            @{self}.then( function (value) {
+            @{self}.then( function ( value ) {
                 callback( value, true );
-            }, function (value) {
+            }, function ( value ) {
                 callback( value, false );
             } );
         }

--- a/src/webcore/promise.rs
+++ b/src/webcore/promise.rs
@@ -16,12 +16,9 @@ use webcore::promise_executor::spawn;
 ///
 /// [(JavaScript docs)](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise)
 // https://www.ecma-international.org/ecma-262/6.0/#sec-promise-objects
+#[derive(Clone, Debug, ReferenceType)]
+#[reference(instance_of = "Promise")]
 pub struct Promise( Reference );
-
-reference_boilerplate! {
-    Promise,
-    instanceof Promise
-}
 
 impl Promise {
     // https://www.ecma-international.org/ecma-262/6.0/#sec-promise-resolve-functions

--- a/src/webcore/promise.rs
+++ b/src/webcore/promise.rs
@@ -169,6 +169,9 @@ impl Promise {
 /// Convert a JavaScript `Promise` into a `PromiseFuture`:
 ///
 /// ```rust
+/// use stdweb::PromiseFuture;
+/// use stdweb::web::error::Error;
+///
 /// let future: PromiseFuture<String, Error> = js!( return Promise.resolve("foo"); ).try_into().unwrap();
 /// ```
 pub struct PromiseFuture< A, B > {

--- a/src/webcore/promise.rs
+++ b/src/webcore/promise.rs
@@ -6,7 +6,7 @@ use webcore::value::{Value, Reference, ConversionError};
 use webcore::try_from::{TryInto, TryFrom};
 use web::error::Error as JSError;
 use futures::{future, Future, Poll};
-use futures::sync::oneshot::channel;
+use futures::unsync::oneshot::channel;
 
 
 pub struct Promise( Reference );

--- a/src/webcore/promise.rs
+++ b/src/webcore/promise.rs
@@ -10,7 +10,11 @@ use futures::unsync::oneshot::{Receiver, channel};
 use webcore::promise_executor::spawn;
 
 
+/// A `Promise` object represents the eventual completion (or failure) of an asynchronous operation, and its resulting value.
 ///
+/// In most situations you shouldn't use this, use [`PromiseFuture`](struct.PromiseFuture.html) instead.
+///
+/// [(JavaScript docs)](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise)
 pub struct Promise( Reference );
 
 reference_boilerplate! {
@@ -19,12 +23,62 @@ reference_boilerplate! {
 }
 
 impl Promise {
+    /// This function should rarely be needed, use [`PromiseFuture`](struct.PromiseFuture.html) instead.
     ///
+    /// This function is used for two different purposes:
+    ///
+    /// 1. If you have a JavaScript value which is not a `Promise` but you want to wrap it in a `Promise`, you can use `Promise::promisify(value)`.
+    ///    In this situation, it is recommended to use [`futures::future::ok`](https://docs.rs/futures/0.1.18/futures/future/fn.ok.html) instead.
+    ///
+    /// 2. If you have a JavaScript value which is a Promise-like object (it has a `then` method) but it isn't a true `Promise`, you can use
+    ///    `Promise::promisify(value)` to convert it into a true `Promise`. This situation is rare, but it can happen if you are using a Promise
+    ///    library such as jQuery or Bluebird.
+    ///
+    /// # Examples
+    ///
+    /// Convert a JavaScript value to a `Promise`:
+    ///
+    /// ```rust
+    /// Promise::promisify(js!( return 5; ))
+    /// ```
+    ///
+    /// Convert a Promise-like object to a `Promise`:
+    ///
+    /// ```rust
+    /// // jQuery Promise
+    /// Promise::promisify(js!( return $.get("test.php"); ))
+    ///
+    /// // Bluebird Promise
+    /// Promise::promisify(js!( return bluebird_promise.timeout(1000); ))
+    /// ```
+    ///
+    /// [(JavaScript docs)](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise/resolve)
     pub fn promisify( input: Value ) -> Promise {
         js!( return Promise.resolve( @{input} ); ).try_into().unwrap()
     }
 
+    /// This method is usually not needed, use [`PromiseFuture`](struct.PromiseFuture.html) instead.
     ///
+    /// When the `Promise` either succeeds or fails, it calls the `callback` with the result.
+    ///
+    /// It does not wait for the `Promise` to succeed / fail (it does not block the thread).
+    ///
+    /// The `callback` is guaranteed to be called asynchronously even if the `Promise` is already succeeded / failed.
+    ///
+    /// If the `Promise` never succeeds / fails then the `callback` will never be called, and it will leak memory.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// promise.done(|result| {
+    ///     match result {
+    ///         Ok(success) => { ... },
+    ///         Err(error) => { ... },
+    ///     }
+    /// });
+    /// ```
+    ///
+    /// [(JavaScript docs)](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise/then)
     pub fn done< A, B >( &self, callback: B )
         where A: TryFrom< Value >,
               A::Error: Error,
@@ -54,7 +108,15 @@ impl Promise {
         }
     }
 
+    /// This method should rarely be needed, instead use [`value.try_into()`](unstable/trait.TryInto.html) to convert directly from a [`Value`](enum.Value.html) into a [`PromiseFuture`](struct.PromiseFuture.html).
     ///
+    /// This method converts the `Promise` into a [`PromiseFuture`](struct.PromiseFuture.html), so that it can be used as a Rust [`Future`](https://docs.rs/futures/0.1.18/futures/future/trait.Future.html).
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// promise.to_future().map(|x| x + 1)
+    /// ```
     // We can't use the IntoFuture trait because Promise doesn't have a type argument
     // TODO explain more why we can't use the IntoFuture trait
     pub fn to_future< A >( &self ) -> PromiseFuture< A >
@@ -79,7 +141,17 @@ impl Promise {
 }
 
 
+/// This allows you to use a JavaScript [`Promise`](struct.Promise.html) as if it is a Rust [`Future`](https://docs.rs/futures/0.1.18/futures/future/trait.Future.html).
 ///
+/// The preferred way to create a `PromiseFuture` is to use [`value.try_into()`](unstable/trait.TryInto.html) on a JavaScript [`Value`](enum.Value.html).
+///
+/// # Examples
+///
+/// Convert a JavaScript `Promise` into a `PromiseFuture`:
+///
+/// ```rust
+/// let future: PromiseFuture<String> = js!( return Promise.resolve("foo"); ).try_into().unwrap();
+/// ```
 pub struct PromiseFuture< A > {
     future: Receiver< Result< A, JSError > >,
     phantom: PhantomData< A >,
@@ -87,7 +159,21 @@ pub struct PromiseFuture< A > {
 
 
 impl PromiseFuture< () > {
+    /// Asynchronously runs the [`Future`](https://docs.rs/futures/0.1.18/futures/future/trait.Future.html) and immediately returns. This does not block the current thread.
     ///
+    /// If the [`Future`](https://docs.rs/futures/0.1.18/futures/future/trait.Future.html) errors it will print the error to the console.
+    ///
+    /// This function is normally called once in `main`, it is usually not needed to call it multiple times.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// fn main() {
+    ///     create_some_future()
+    ///         .inspect(|x| println!("Future finished: {:#?}", x))
+    ///         .spawn()
+    /// }
+    /// ```
     pub fn spawn< B >( future: B ) where
         B: Future< Item = (), Error = JSError > + 'static {
 

--- a/src/webcore/promise.rs
+++ b/src/webcore/promise.rs
@@ -163,7 +163,7 @@ pub struct PromiseFuture< A > {
 }
 
 impl PromiseFuture< () > {
-    /// Asynchronously runs the [`Future`](https://docs.rs/futures/0.1.18/futures/future/trait.Future.html) and immediately returns. This does not block the current thread.
+    /// Asynchronously runs the [`Future`](https://docs.rs/futures/0.1.18/futures/future/trait.Future.html) and then immediately returns. This does not block the current thread.
     ///
     /// If the [`Future`](https://docs.rs/futures/0.1.18/futures/future/trait.Future.html) errors it will print the error to the console.
     ///
@@ -176,7 +176,7 @@ impl PromiseFuture< () > {
     ///     PromiseFuture::spawn(
     ///         create_some_future()
     ///             .inspect(|x| println!("Future finished: {:#?}", x))
-    ///     )
+    ///     );
     /// }
     /// ```
     pub fn spawn< B >( future: B ) where

--- a/src/webcore/promise.rs
+++ b/src/webcore/promise.rs
@@ -163,61 +163,29 @@ pub struct PromiseFuture< A > {
 }
 
 impl PromiseFuture< () > {
-    /// This is identical to [`spawn`](#method.spawn), except that if the [`Future`](https://docs.rs/futures/0.1.18/futures/future/trait.Future.html) errors it will print the error to the console. See the documentation of [`spawn`](#method.spawn) for more details.
+    /// Asynchronously runs the [`Future`](https://docs.rs/futures/0.1.18/futures/future/trait.Future.html) and then immediately returns.
+    /// This does not block the current thread. The only way to retrieve the value of the future is to use the various
+    /// [`Future`](https://docs.rs/futures/0.1.18/futures/future/trait.Future.html) methods, such as
+    /// [`map`](https://docs.rs/futures/0.1.18/futures/future/trait.Future.html#method.map) or
+    /// [`inspect`](https://docs.rs/futures/0.1.18/futures/future/trait.Future.html#method.inspect).
     ///
-    /// If you want to handle all errors yourself, then use [`spawn`](#method.spawn), but if you simply want to print the errors to the console, then use `spawn_print`.
+    /// This function requires you to handle all errors yourself. Because the errors happen asynchronously, the only way to catch them is
+    /// to use a [`Future`](https://docs.rs/futures/0.1.18/futures/future/trait.Future.html) method, such as
+    /// [`map_err`](https://docs.rs/futures/0.1.18/futures/future/trait.Future.html#method.map_err).
     ///
-    /// # Examples
-    ///
-    /// Asynchronously run a future in `main`:
-    ///
-    /// ```rust
-    /// fn main() {
-    ///     PromiseFuture::spawn_print(
-    ///         create_some_future()
-    ///     );
-    /// }
-    /// ```
-    ///
-    /// Inspect the output value of the future:
-    ///
-    /// ```rust
-    /// fn main() {
-    ///     PromiseFuture::spawn_print(
-    ///         create_some_future()
-    ///             .inspect(|x| println!("Future finished: {:#?}", x))
-    ///     );
-    /// }
-    /// ```
-    pub fn spawn_print< B >( future: B ) where
-        B: Future< Item = (), Error = Error > + 'static {
-
-        spawn( future.map_err( |e| {
-            // TODO better error handling
-            js! { @(no_return)
-                console.error( @{e} );
-            }
-
-            ()
-        } ) );
-    }
-
-    /// Asynchronously runs the [`Future`](https://docs.rs/futures/0.1.18/futures/future/trait.Future.html) and then immediately returns. This does not block the current thread.
+    /// It is very common to want to print the errors to the console. You can do that by using `.map_err(|e| e.print())`
     ///
     /// This function is normally called once in `main`, it is usually not needed to call it multiple times.
     ///
-    /// Because the error happens asynchronously, the only way to catch it is to use a [`Future`](https://docs.rs/futures/0.1.18/futures/future/trait.Future.html) method, such as [`map_err`](https://docs.rs/futures/0.1.18/futures/future/trait.Future.html#method.map_err).
-    ///
-    /// And the only way to retrieve the value of the future is to use the various [`Future`](https://docs.rs/futures/0.1.18/futures/future/trait.Future.html) methods, such as [`map`](https://docs.rs/futures/0.1.18/futures/future/trait.Future.html#method.map) or [`inspect`](https://docs.rs/futures/0.1.18/futures/future/trait.Future.html#method.inspect).
-    ///
     /// # Examples
     ///
-    /// Asynchronously run a future in `main`:
+    /// Asynchronously run a future in `main`, printing any errors to the console:
     ///
     /// ```rust
     /// fn main() {
     ///     PromiseFuture::spawn(
     ///         create_some_future()
+    ///             .map_err(|e| e.print())
     ///     );
     /// }
     /// ```
@@ -229,11 +197,12 @@ impl PromiseFuture< () > {
     ///     PromiseFuture::spawn(
     ///         create_some_future()
     ///             .inspect(|x| println!("Future finished: {:#?}", x))
+    ///             .map_err(|e| e.print())
     ///     );
     /// }
     /// ```
     ///
-    /// Catch errors and handle them:
+    /// Catch errors and handle them yourself:
     ///
     /// ```rust
     /// fn main() {

--- a/src/webcore/promise.rs
+++ b/src/webcore/promise.rs
@@ -1,11 +1,13 @@
 use std;
 use webcore::once::Once;
-use webcore::value::{Value, Reference, ConversionError};
+use webcore::value::{Value, Reference};
 use webcore::try_from::{TryInto, TryFrom};
-use web::error::Error;
-use futures::{Future, Poll, Async};
-use futures::unsync::oneshot::{Receiver, channel};
-use webcore::promise_executor::spawn;
+
+#[cfg(feature = "futures")]
+use futures::unsync::oneshot::channel;
+
+#[cfg(feature = "futures")]
+use super::promise_future::PromiseFuture;
 
 
 /// A `Promise` object represents the eventual completion (or failure) of an asynchronous operation, and its resulting value.
@@ -136,6 +138,7 @@ impl Promise {
     /// ```
     // We can't use the IntoFuture trait because Promise doesn't have a type argument
     // TODO explain more why we can't use the IntoFuture trait
+    #[cfg(feature = "futures")]
     pub fn to_future< A, B >( &self ) -> PromiseFuture< A, B >
          where A: TryFrom< Value > + 'static,
                B: TryFrom< Value > + 'static,
@@ -156,116 +159,5 @@ impl Promise {
         PromiseFuture {
             future: receiver,
         }
-    }
-}
-
-
-/// This allows you to use a JavaScript [`Promise`](struct.Promise.html) as if it is a Rust [`Future`](https://docs.rs/futures/0.1.18/futures/future/trait.Future.html).
-///
-/// The preferred way to create a `PromiseFuture` is to use [`value.try_into()`](unstable/trait.TryInto.html) on a JavaScript [`Value`](enum.Value.html).
-///
-/// # Examples
-///
-/// Convert a JavaScript `Promise` into a `PromiseFuture`:
-///
-/// ```rust
-/// use stdweb::PromiseFuture;
-/// use stdweb::web::error::Error;
-///
-/// let future: PromiseFuture<String, Error> = js!( return Promise.resolve("foo"); ).try_into().unwrap();
-/// ```
-pub struct PromiseFuture< A, B > {
-    future: Receiver< Result< A, B > >,
-}
-
-impl PromiseFuture< (), () > {
-    /// Asynchronously runs the [`Future`](https://docs.rs/futures/0.1.18/futures/future/trait.Future.html) and then immediately returns.
-    /// This does not block the current thread. The only way to retrieve the value of the future is to use the various
-    /// [`Future`](https://docs.rs/futures/0.1.18/futures/future/trait.Future.html) methods, such as
-    /// [`map`](https://docs.rs/futures/0.1.18/futures/future/trait.Future.html#method.map) or
-    /// [`inspect`](https://docs.rs/futures/0.1.18/futures/future/trait.Future.html#method.inspect).
-    ///
-    /// This function requires you to handle all errors yourself. Because the errors happen asynchronously, the only way to catch them is
-    /// to use a [`Future`](https://docs.rs/futures/0.1.18/futures/future/trait.Future.html) method, such as
-    /// [`map_err`](https://docs.rs/futures/0.1.18/futures/future/trait.Future.html#method.map_err).
-    ///
-    /// It is very common to want to print the errors to the console. You can do that by using `.map_err(|e| e.print())`
-    ///
-    /// This function is normally called once in `main`, it is usually not needed to call it multiple times.
-    ///
-    /// # Examples
-    ///
-    /// Asynchronously run a future in `main`, printing any errors to the console:
-    ///
-    /// ```rust
-    /// fn main() {
-    ///     PromiseFuture::spawn(
-    ///         create_some_future()
-    ///             .map_err(|e| e.print())
-    ///     );
-    /// }
-    /// ```
-    ///
-    /// Inspect the output value of the future:
-    ///
-    /// ```rust
-    /// fn main() {
-    ///     PromiseFuture::spawn(
-    ///         create_some_future()
-    ///             .inspect(|x| println!("Future finished: {:#?}", x))
-    ///             .map_err(|e| e.print())
-    ///     );
-    /// }
-    /// ```
-    ///
-    /// Catch errors and handle them yourself:
-    ///
-    /// ```rust
-    /// fn main() {
-    ///     PromiseFuture::spawn(
-    ///         create_some_future()
-    ///             .map_err(|e| handle_error_somehow(e))
-    ///     );
-    /// }
-    /// ```
-    #[inline]
-    pub fn spawn< B >( future: B ) where
-        B: Future< Item = (), Error = () > + 'static {
-        spawn( future );
-    }
-}
-
-impl< A, B > std::fmt::Debug for PromiseFuture< A, B > {
-    fn fmt( &self, formatter: &mut std::fmt::Formatter ) -> std::fmt::Result {
-        write!( formatter, "PromiseFuture" )
-    }
-}
-
-impl< A, B > Future for PromiseFuture< A, B > {
-    type Item = A;
-    type Error = B;
-
-    fn poll( &mut self ) -> Poll< Self::Item, Self::Error > {
-        // TODO maybe remove this unwrap ?
-        match self.future.poll().unwrap() {
-            Async::Ready( Ok( a ) ) => Ok( Async::Ready( a ) ),
-            Async::Ready( Err( e ) ) => Err( e ),
-            Async::NotReady => Ok( Async::NotReady ),
-        }
-    }
-}
-
-impl< A, B > TryFrom< Value > for PromiseFuture< A, B >
-    where A: TryFrom< Value > + 'static,
-          B: TryFrom< Value > + 'static,
-          // TODO remove this later
-          A::Error: std::fmt::Debug,
-          B::Error: std::fmt::Debug {
-
-    type Error = ConversionError;
-
-    fn try_from( v: Value ) -> Result< Self, Self::Error > {
-        let promise: Promise = v.try_into()?;
-        Ok( promise.to_future() )
     }
 }

--- a/src/webcore/promise.rs
+++ b/src/webcore/promise.rs
@@ -1,20 +1,86 @@
 use std;
-use std::marker::PhantomData;
-use {Value, Once};
-use unstable::{TryInto, TryFrom};
-use webcore::value::ConversionError;
-use web::error::Error as JSError;
 use std::error::Error;
+use std::marker::PhantomData;
+use webcore::once::Once;
+use webcore::value::{Value, Reference, ConversionError};
+use webcore::try_from::{TryInto, TryFrom};
+use web::error::Error as JSError;
 use futures::{future, Future, Poll};
 use futures::sync::oneshot::channel;
 
 
-// TODO split this into Promise and PromiseFuture
+pub struct Promise( Reference );
+
+reference_boilerplate! {
+    Promise,
+    instanceof Promise
+}
+
+impl Promise {
+    pub fn done< A, B >( &self, callback: B ) -> Self
+        where A: TryFrom< Value >,
+              A::Error: Error,
+              B: FnOnce( Result< A, JSError > ) + 'static {
+
+        let callback = |value: Value, success: bool| {
+            let value: Result< A, JSError > = if success {
+                let value: Result< A, A::Error > = value.try_into();
+                value.map_err( |e| JSError::new( e.description() ) )
+            } else {
+                let value: Result< JSError, ConversionError > = value.try_into();
+                value.map_err( |e| JSError::new( e.description() ) ).and_then( Err )
+            };
+
+            callback( value );
+        };
+
+        (js! {
+            var callback = @{Once( callback )};
+
+            return @{self}.then( function (value) {
+                callback( value, true );
+            }, function (value) {
+                callback( value, false );
+            } );
+        }).try_into().unwrap()
+    }
+
+    // We can't use the IntoFuture trait because Promise doesn't have a type argument
+    // TODO explain more why we can't use the IntoFuture trait
+    pub fn to_future< A >( &self ) -> PromiseFuture< A >
+         where A: TryFrom< Value > + 'static,
+               A::Error: Error {
+
+        let ( sender, receiver ) = channel();
+
+        PromiseFuture {
+            promise: self.done( |value| {
+                // TODO is this correct ?
+                match sender.send( value ) {
+                    Ok( _ ) => {},
+                    Err( _ ) => {},
+                };
+            } ),
+            future: Box::new( receiver.map_err( |x| JSError::new( x.description() ) ).and_then( future::result ) ),
+            phantom: PhantomData,
+        }
+    }
+}
+
+
 pub struct PromiseFuture< A > {
-    promise: Value,
+    promise: Promise,
     future: Box< Future< Item = A, Error = JSError > >,
     phantom: PhantomData< A >,
 }
+
+
+/*impl< A > PromiseFuture< A > {
+    pub fn new< B >( callback: B ) -> Self
+        where B: FnOnce( FnOnce( A ), FnOnce( JSError ) ) {
+        js!( return new Promise( @{Once( callback )} ); ).try_from().unwrap()
+    }
+}*/
 
 
 impl< A > std::fmt::Debug for PromiseFuture< A > {
@@ -22,7 +88,6 @@ impl< A > std::fmt::Debug for PromiseFuture< A > {
         write!( formatter, "PromiseFuture {:?}", self.promise )
     }
 }
-
 
 impl< A > Future for PromiseFuture< A > {
     type Item = A;
@@ -33,47 +98,14 @@ impl< A > Future for PromiseFuture< A > {
     }
 }
 
+impl< A > TryFrom< Value > for PromiseFuture< A >
+    where A: TryFrom< Value > + 'static,
+          A::Error: Error {
 
-// TODO this should probably check instanceof Promise
-impl< A: TryFrom< Value > > TryFrom< Value > for PromiseFuture< A > where A: 'static, A::Error: Error {
     type Error = ConversionError;
 
     fn try_from( v: Value ) -> Result< Self, Self::Error > {
-        match v {
-            Value::Reference( ref r ) => {
-                let ( sender, receiver ) = channel();
-
-                let callback = |value: Value, success: bool| {
-                    let value: Result< A, JSError > = if success {
-                        let value: Result< A, A::Error > = value.try_into();
-                        value.map_err( |e| JSError::new( e.description() ) )
-                    } else {
-                        let value: Result< JSError, ConversionError > = value.try_into();
-                        value.map_err( |e| JSError::new( e.description() ) ).and_then( Err )
-                    };
-
-                    // TODO is this correct ?
-                    match sender.send( value ) {
-                        Ok( _ ) => {},
-                        Err( _ ) => {},
-                    };
-                };
-
-                Ok( PromiseFuture {
-                    promise: js! {
-                        var callback = @{Once( callback )};
-
-                        return @{r}.then( function (value) {
-                            callback( value, true );
-                        }, function (value) {
-                            callback( value, false );
-                        } );
-                    },
-                    future: Box::new( receiver.map_err( |x| JSError::new( x.description() ) ).and_then( future::result ) ),
-                    phantom: PhantomData,
-                } )
-            },
-            other => Err( ConversionError::Custom( format!( "Expected Promise but got: {:?}", other ) ) ),
-        }
+        let promise: Promise = v.try_into()?;
+        Ok( promise.to_future() )
     }
 }

--- a/src/webcore/promise.rs
+++ b/src/webcore/promise.rs
@@ -20,7 +20,7 @@ pub struct Promise( Reference );
 
 impl Promise {
     // https://www.ecma-international.org/ecma-262/6.0/#sec-promise-resolve-functions
-    fn is_promise_like( input: &Value ) -> bool {
+    fn is_thenable( input: &Value ) -> bool {
         (js! {
             var input = @{input};
             // This emulates the `Type(input) is Object` and `IsCallable(input.then)` ECMAScript abstract operations.
@@ -37,7 +37,7 @@ impl Promise {
     /// That situation is rare, but it can happen if you are using a Promise library such as jQuery or
     /// Bluebird.
     ///
-    /// In that situation you can use `Promise::convert(value)` to convert it into a true `Promise`.
+    /// In that situation you can use `Promise::from_thenable(value)` to convert it into a true `Promise`.
     ///
     /// If the `input` isn't a Promise-like object then it returns `None`.
     ///
@@ -47,19 +47,20 @@ impl Promise {
     ///
     /// ```rust
     /// // jQuery Promise
-    /// Promise::convert(js!( return $.get("test.php"); ))
+    /// Promise::from_thenable(js!( return $.get("test.php"); ))
     ///
     /// // Bluebird Promise
-    /// Promise::convert(js!( return bluebird_promise.timeout(1000); ))
+    /// Promise::from_thenable(js!( return bluebird_promise.timeout(1000); ))
     /// ```
     ///
     /// [(JavaScript docs)](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise/resolve)
     // https://www.ecma-international.org/ecma-262/6.0/#sec-promise.resolve
     // https://www.ecma-international.org/ecma-262/6.0/#sec-promise-resolve-functions
     // https://www.ecma-international.org/ecma-262/6.0/#sec-promiseresolvethenablejob
-    pub fn convert( input: Value ) -> Option< Self > {
+    // TODO change this later to use &Reference
+    pub fn from_thenable( input: Value ) -> Option< Self > {
         // TODO this can probably be made more efficient
-        if Promise::is_promise_like( &input ) {
+        if Promise::is_thenable( &input ) {
             Some( js!( return Promise.resolve( @{input} ); ).try_into().unwrap() )
 
         } else {

--- a/src/webcore/promise.rs
+++ b/src/webcore/promise.rs
@@ -163,23 +163,33 @@ pub struct PromiseFuture< A > {
 }
 
 impl PromiseFuture< () > {
-    /// Asynchronously runs the [`Future`](https://docs.rs/futures/0.1.18/futures/future/trait.Future.html) and then immediately returns. This does not block the current thread.
+    /// This is identical to [`spawn`](#method.spawn), except that if the [`Future`](https://docs.rs/futures/0.1.18/futures/future/trait.Future.html) errors it will print the error to the console. See the documentation of [`spawn`](#method.spawn) for more details.
     ///
-    /// If the [`Future`](https://docs.rs/futures/0.1.18/futures/future/trait.Future.html) errors it will print the error to the console.
-    ///
-    /// This function is normally called once in `main`, it is usually not needed to call it multiple times.
+    /// If you want to handle all errors yourself, then use [`spawn`](#method.spawn), but if you simply want to print the errors to the console, then use `spawn_print`.
     ///
     /// # Examples
     ///
+    /// Asynchronously run a future in `main`:
+    ///
     /// ```rust
     /// fn main() {
-    ///     PromiseFuture::spawn(
+    ///     PromiseFuture::spawn_print(
+    ///         create_some_future()
+    ///     );
+    /// }
+    /// ```
+    ///
+    /// Inspect the output value of the future:
+    ///
+    /// ```rust
+    /// fn main() {
+    ///     PromiseFuture::spawn_print(
     ///         create_some_future()
     ///             .inspect(|x| println!("Future finished: {:#?}", x))
     ///     );
     /// }
     /// ```
-    pub fn spawn< B >( future: B ) where
+    pub fn spawn_print< B >( future: B ) where
         B: Future< Item = (), Error = Error > + 'static {
 
         spawn( future.map_err( |e| {
@@ -190,6 +200,53 @@ impl PromiseFuture< () > {
 
             ()
         } ) );
+    }
+
+    /// Asynchronously runs the [`Future`](https://docs.rs/futures/0.1.18/futures/future/trait.Future.html) and then immediately returns. This does not block the current thread.
+    ///
+    /// This function is normally called once in `main`, it is usually not needed to call it multiple times.
+    ///
+    /// Because the error happens asynchronously, the only way to catch it is to use a [`Future`](https://docs.rs/futures/0.1.18/futures/future/trait.Future.html) method, such as [`map_err`](https://docs.rs/futures/0.1.18/futures/future/trait.Future.html#method.map_err).
+    ///
+    /// And the only way to retrieve the value of the future is to use the various [`Future`](https://docs.rs/futures/0.1.18/futures/future/trait.Future.html) methods, such as [`map`](https://docs.rs/futures/0.1.18/futures/future/trait.Future.html#method.map) or [`inspect`](https://docs.rs/futures/0.1.18/futures/future/trait.Future.html#method.inspect).
+    ///
+    /// # Examples
+    ///
+    /// Asynchronously run a future in `main`:
+    ///
+    /// ```rust
+    /// fn main() {
+    ///     PromiseFuture::spawn(
+    ///         create_some_future()
+    ///     );
+    /// }
+    /// ```
+    ///
+    /// Inspect the output value of the future:
+    ///
+    /// ```rust
+    /// fn main() {
+    ///     PromiseFuture::spawn(
+    ///         create_some_future()
+    ///             .inspect(|x| println!("Future finished: {:#?}", x))
+    ///     );
+    /// }
+    /// ```
+    ///
+    /// Catch errors and handle them:
+    ///
+    /// ```rust
+    /// fn main() {
+    ///     PromiseFuture::spawn(
+    ///         create_some_future()
+    ///             .map_err(|e| handle_error_somehow(e))
+    ///     );
+    /// }
+    /// ```
+    #[inline]
+    pub fn spawn< B >( future: B ) where
+        B: Future< Item = (), Error = () > + 'static {
+        spawn( future );
     }
 }
 

--- a/src/webcore/promise.rs
+++ b/src/webcore/promise.rs
@@ -17,6 +17,10 @@ reference_boilerplate! {
 }
 
 impl Promise {
+    pub fn promisify( input: Value ) -> Promise {
+        js!( return Promise.resolve( @{input} ); ).try_into().unwrap()
+    }
+
     pub fn done< A, B >( &self, callback: B )
         where A: TryFrom< Value >,
               A::Error: Error,
@@ -94,7 +98,7 @@ impl< A > Future for PromiseFuture< A > {
     type Item = A;
     type Error = JSError;
 
-    fn poll (&mut self ) -> Poll< Self::Item, Self::Error > {
+    fn poll( &mut self ) -> Poll< Self::Item, Self::Error > {
         self.future.poll()
     }
 }

--- a/src/webcore/promise_executor.rs
+++ b/src/webcore/promise_executor.rs
@@ -1,4 +1,4 @@
-use futures::future::{Future, lazy, ExecuteError, Executor, IntoFuture};
+use futures::future::{Future, ExecuteError, Executor};
 use futures::executor::{self, Notify, Spawn};
 use futures::Async;
 use std::result::Result as StdResult;

--- a/src/webcore/promise_executor.rs
+++ b/src/webcore/promise_executor.rs
@@ -1,0 +1,111 @@
+use futures::future::{Future, lazy, ExecuteError, Executor, IntoFuture};
+use futures::executor::{self, Notify, Spawn};
+use futures::Async;
+use std::result::Result as StdResult;
+use std::cell::{Cell, RefCell};
+
+
+struct SpawnedTask {
+    ref_count: Cell< usize >,
+    spawn: RefCell< Spawn< Box< Future<Item = (), Error = () > + 'static > > >,
+}
+
+impl SpawnedTask {
+    fn new< F >( future: F ) -> Self
+        where F: Future< Item = (), Error = () > + 'static {
+        Self {
+            ref_count: Cell::new( 1 ),
+            spawn: RefCell::new( executor::spawn( Box::new( future.fuse() )
+                as Box< Future<Item = (), Error = () > + 'static> ) ),
+        }
+    }
+
+    fn execute_spawn( spawned_ptr: *const SpawnedTask ) {
+        let spawned = unsafe { &*spawned_ptr };
+
+        // This is probably suboptimal, as a resubmission of the same Task while it
+        // is being executed results in a panic. It is not entirely clear if a Task
+        // is allowed to do that, but I would expect that this is valid behavior, as
+        // the notification could happen while the Task is still executing, in a
+        // truly multi-threaded situation. So we probably have to deal with it here
+        // at some point too. This already happened in the IntervalStream, so that
+        // should be cleaned up then as well then. The easiest solution is to try to
+        // lock it instead and if it fails, increment a counter. The one that
+        // initially blocked the RefCell then just reexecutes the Task until the
+        // Task is finished or the counter reaches 0.
+
+        if spawned.spawn.borrow_mut().poll_future_notify( &CORE, spawned_ptr as usize ) != Ok( Async::NotReady ) {
+            SpawnedTask::decrement_ref_count( spawned_ptr as usize );
+        }
+    }
+
+    fn decrement_ref_count( id: usize ) {
+        let count = {
+            let spawned_ptr = id as *const SpawnedTask;
+            let spawned = unsafe { &*spawned_ptr };
+            let mut count = spawned.ref_count.get();
+            count -= 1;
+            spawned.ref_count.set( count );
+            println!("Drop {}", count);
+            count
+        };
+
+        if count == 0 {
+            let spawned_ptr = id as *mut SpawnedTask;
+            unsafe { Box::from_raw( spawned_ptr ) };
+        }
+    }
+}
+
+
+static CORE: &Core = &Core;
+
+struct Core;
+
+impl< F > Executor< F > for Core where
+    F: Future< Item = (), Error = () > + 'static {
+    fn execute( &self, future: F ) -> StdResult< (), ExecuteError< F > > {
+        println!("Execute");
+
+        let spawned_ptr = Box::into_raw( Box::new( SpawnedTask::new( future ) ) );
+
+        SpawnedTask::execute_spawn( spawned_ptr );
+
+        println!("Execute End");
+
+        Ok( () )
+    }
+}
+
+impl Notify for Core {
+    fn notify( &self, spawned_id: usize ) {
+        println!("Notify");
+
+        let spawned_ptr = spawned_id as *const SpawnedTask;
+
+        SpawnedTask::execute_spawn( spawned_ptr );
+
+        println!("Notify End");
+    }
+
+    fn clone_id( &self, id: usize ) -> usize {
+        let spawned_ptr = id as *const SpawnedTask;
+        let spawned = unsafe { &*spawned_ptr };
+        let mut count = spawned.ref_count.get();
+        count += 1;
+        spawned.ref_count.set( count );
+        println!("Clone {}", count);
+        id
+    }
+
+    fn drop_id( &self, id: usize ) {
+        SpawnedTask::decrement_ref_count( id );
+    }
+}
+
+
+#[inline]
+pub fn spawn< F >( future: F ) where
+    F: Future< Item = (), Error = () > + 'static {
+    CORE.execute( future ).ok();
+}

--- a/src/webcore/promise_executor.rs
+++ b/src/webcore/promise_executor.rs
@@ -34,13 +34,13 @@ impl SpawnedTask {
     }
 
     fn poll(&self) {
-        // Clear `is_queued` flag
-        self.is_queued.set(false);
-
         let mut spawn = self.spawn.borrow_mut();
 
         // Take the future so that if we panic it gets dropped
         if let Some(mut spawn_future) = spawn.take() {
+            // Clear `is_queued` flag
+            self.is_queued.set(false);
+
             if spawn_future.poll_future_notify( &&Core, self as *const _ as usize ) == Ok(Async::NotReady) {
                 // Future was not ready, so put it back
                 *spawn = Some(spawn_future);

--- a/src/webcore/promise_executor.rs
+++ b/src/webcore/promise_executor.rs
@@ -14,6 +14,7 @@ enum TaskState {
 
 struct SpawnedTask {
     state: Cell< TaskState >,
+    // TODO use Rc<SpawnedTask> instead ?
     ref_count: Cell< usize >,
     spawn: RefCell< Spawn< Box< Future< Item = (), Error = () > + 'static > > >,
 }

--- a/src/webcore/promise_executor.rs
+++ b/src/webcore/promise_executor.rs
@@ -8,9 +8,9 @@ use webcore::once::Once;
 
 // This functionality should really be in libstd, because the implementation
 // looks stupid.
-unsafe fn clone_raw<T>(ptr: *const T) -> Rc<T> {
-    let result = Rc::from_raw(ptr);
-    ::std::mem::forget(result.clone());
+unsafe fn clone_raw< T >( ptr: *const T ) -> Rc< T > {
+    let result = Rc::from_raw( ptr );
+    ::std::mem::forget( result.clone() );
     result
 }
 
@@ -19,43 +19,43 @@ type BoxedFuture = Box< Future< Item = (), Error = () > + 'static >;
 
 struct SpawnedTask {
     is_queued: Cell< bool >,
-    spawn: RefCell< Option< Spawn< BoxedFuture > >  >,
+    spawn: RefCell< Option< Spawn< BoxedFuture > > >,
 }
 
 impl SpawnedTask {
-    fn new< F >( future: F ) -> Rc<Self>
+    fn new< F >( future: F ) -> Rc< Self >
         where F: Future< Item = (), Error = () > + 'static {
-        Rc::new(Self {
+        Rc::new( Self {
             is_queued: Cell::new( false ),
             spawn: RefCell::new( Some( executor::spawn(
                 Box::new( future ) as BoxedFuture
             ) ) ),
-        })
+        } )
     }
 
     fn poll(&self) {
         let mut spawn = self.spawn.borrow_mut();
 
         // Take the future so that if we panic it gets dropped
-        if let Some(mut spawn_future) = spawn.take() {
+        if let Some( mut spawn_future ) = spawn.take() {
             // Clear `is_queued` flag
-            self.is_queued.set(false);
+            self.is_queued.set( false );
 
-            if spawn_future.poll_future_notify( &&Core, self as *const _ as usize ) == Ok(Async::NotReady) {
+            if spawn_future.poll_future_notify( &&Core, self as *const _ as usize ) == Ok( Async::NotReady ) {
                 // Future was not ready, so put it back
-                *spawn = Some(spawn_future);
+                *spawn = Some( spawn_future );
             }
         }
     }
 
-    fn notify( spawned: Rc<SpawnedTask> ) {
+    fn notify( spawned: Rc< SpawnedTask > ) {
         // If not already queued
-        if !spawned.is_queued.replace(true) {
+        if !spawned.is_queued.replace( true ) {
             // Poll on next micro-task
             js! { @(no_return)
-                Promise.resolve().then(function() {
-                    @{ Once(move || spawned.poll()) }();
-                });
+                Promise.resolve().then( function () {
+                    @{Once( move || spawned.poll() )}();
+                } );
             }
         }
     }
@@ -73,15 +73,15 @@ impl< F > Executor< F > for Core where
 
 impl Notify for Core {
     fn notify( &self, spawned_id: usize ) {
-        SpawnedTask::notify(unsafe { clone_raw(spawned_id as *const _) })
+        SpawnedTask::notify( unsafe { clone_raw( spawned_id as *const _ ) } )
     }
 
     fn clone_id( &self, id: usize ) -> usize {
-        unsafe { Rc::into_raw(clone_raw(id as *const SpawnedTask)) as usize }
+        unsafe { Rc::into_raw( clone_raw( id as *const SpawnedTask ) ) as usize }
     }
 
     fn drop_id( &self, id: usize ) {
-        unsafe { Rc::from_raw(id as *const SpawnedTask) };
+        unsafe { Rc::from_raw( id as *const SpawnedTask ) };
     }
 }
 

--- a/src/webcore/promise_executor.rs
+++ b/src/webcore/promise_executor.rs
@@ -1,3 +1,31 @@
+//! This code was originally written by @CryZe
+//! https://github.com/CryZe/stdweb-io/blob/9b8429e2452a699e8280cca50ea48f7e6af30c41/src/core.rs
+//!
+//! It is provided under the following license:
+//!
+//! MIT License
+//!
+//! Copyright (c) 2017 Christopher Serr
+//!
+//! Permission is hereby granted, free of charge, to any person obtaining a copy
+//! of this software and associated documentation files (the "Software"), to deal
+//! in the Software without restriction, including without limitation the rights
+//! to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//! copies of the Software, and to permit persons to whom the Software is
+//! furnished to do so, subject to the following conditions:
+//!
+//! The above copyright notice and this permission notice shall be included in all
+//! copies or substantial portions of the Software.
+//!
+//! THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//! IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//! FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//! AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//! LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//! OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+//! SOFTWARE.
+
+
 use futures::future::{Future, ExecuteError, Executor};
 use futures::executor::{self, Notify, Spawn};
 use futures::Async;

--- a/src/webcore/promise_executor.rs
+++ b/src/webcore/promise_executor.rs
@@ -33,7 +33,7 @@ impl SpawnedTask {
         } )
     }
 
-    fn poll(&self) {
+    fn poll( &self ) {
         let mut spawn = self.spawn.borrow_mut();
 
         // Take the future so that if we panic it gets dropped

--- a/src/webcore/promise_executor.rs
+++ b/src/webcore/promise_executor.rs
@@ -46,7 +46,6 @@ impl SpawnedTask {
             let mut count = spawned.ref_count.get();
             count -= 1;
             spawned.ref_count.set( count );
-            println!("Drop {}", count);
             count
         };
 
@@ -65,13 +64,9 @@ struct Core;
 impl< F > Executor< F > for Core where
     F: Future< Item = (), Error = () > + 'static {
     fn execute( &self, future: F ) -> StdResult< (), ExecuteError< F > > {
-        println!("Execute");
-
         let spawned_ptr = Box::into_raw( Box::new( SpawnedTask::new( future ) ) );
 
         SpawnedTask::execute_spawn( spawned_ptr );
-
-        println!("Execute End");
 
         Ok( () )
     }
@@ -79,13 +74,9 @@ impl< F > Executor< F > for Core where
 
 impl Notify for Core {
     fn notify( &self, spawned_id: usize ) {
-        println!("Notify");
-
         let spawned_ptr = spawned_id as *const SpawnedTask;
 
         SpawnedTask::execute_spawn( spawned_ptr );
-
-        println!("Notify End");
     }
 
     fn clone_id( &self, id: usize ) -> usize {
@@ -94,7 +85,6 @@ impl Notify for Core {
         let mut count = spawned.ref_count.get();
         count += 1;
         spawned.ref_count.set( count );
-        println!("Clone {}", count);
         id
     }
 

--- a/src/webcore/promise_executor.rs
+++ b/src/webcore/promise_executor.rs
@@ -3,180 +3,85 @@ use futures::executor::{self, Notify, Spawn};
 use futures::Async;
 use std::result::Result as StdResult;
 use std::cell::{Cell, RefCell};
+use std::rc::Rc;
+use webcore::once::Once;
 
-
-#[derive(Clone, Copy)]
-enum TaskState {
-    Idle,
-    Running,
-    Queued,
+// This functionality should really be in libstd, because the implementation
+// looks stupid.
+unsafe fn clone_raw<T>(ptr: *const T) -> Rc<T> {
+    let result = Rc::from_raw(ptr);
+    ::std::mem::forget(result.clone());
+    result
 }
 
+// Typing this out is tedious
+type BoxedFuture = Box< Future< Item = (), Error = () > + 'static >;
+
 struct SpawnedTask {
-    state: Cell< TaskState >,
-    // TODO use Rc<SpawnedTask> instead ?
-    ref_count: Cell< usize >,
-    spawn: RefCell< Spawn< Box< Future< Item = (), Error = () > + 'static > > >,
+    is_queued: Cell< bool >,
+    spawn: RefCell< Option< Spawn< BoxedFuture > >  >,
 }
 
 impl SpawnedTask {
-    fn new< F >( future: F ) -> Self
+    fn new< F >( future: F ) -> Rc<Self>
         where F: Future< Item = (), Error = () > + 'static {
-        Self {
-            state: Cell::new( TaskState::Idle ),
-            ref_count: Cell::new( 1 ),
-            spawn: RefCell::new( executor::spawn(
-                Box::new( future ) as Box< Future< Item = (), Error = () > + 'static >
-            ) ),
-        }
+        Rc::new(Self {
+            is_queued: Cell::new( false ),
+            spawn: RefCell::new( Some( executor::spawn(
+                Box::new( future ) as BoxedFuture
+            ) ) ),
+        })
     }
 
-    // These are the situations that this algorithm needs to worry about:
-    //
-    //   execute -> poll
-    //   execute -> poll + poll
-    //   execute -> poll + notify -> repoll
-    //   execute -> poll + notify + notify -> repoll
-    //   execute -> poll + notify -> repoll -> async notify -> repoll
-    //   execute -> poll -> async notify -> repoll
-    //   execute -> poll -> async notify -> repoll + notify -> repoll
-    //   execute -> poll -> async notify -> repoll -> async notify -> repoll
-    //
-    unsafe fn execute_spawn( spawned_ptr: *const SpawnedTask ) {
-        let spawned = &*spawned_ptr;
+    fn poll(&self) {
+        // Clear `is_queued` flag
+        self.is_queued.set(false);
 
-        loop {
-            // This is necessary because the Future might call `task.notify()` inside of `poll`.
-            // If that happens, we need to re-run `poll` again. So we use `state` to indicate
-            // whether we need to re-run `poll` or not.
-            spawned.state.set( TaskState::Running );
+        let mut spawn = self.spawn.borrow_mut();
 
-            // Here we try to call `poll` on the future. This may not be possible,
-            // as the future may already be executed somewhere higher up in the stack.
-            // We know there is at least one execution scheduled, so it's styled more
-            // like a do-while loop.
-            //
-            // The usage of the lock needs to be contained in a scope that is
-            // separate from the decrement_ref_count, as that can deallocate the
-            // whole spawned task, causing a segfault when the RefCell is trying
-            // to release its borrow. That's why the poll_future_notify call is
-            // contained inside the map.
-            let result = spawned
-                .spawn
-                .try_borrow_mut()
-                .map( |mut s| s.poll_future_notify( &CORE, spawned_ptr as usize ) );
-
-            // TODO test this
-            if let Ok( result ) = result {
-                if let Ok( Async::NotReady ) = result {
-                    // The `poll` method called `task.notify()` so we have to re-run `poll` again.
-                    if let TaskState::Queued = spawned.state.get() {
-                        continue;
-
-                    } else {
-                        // The Future isn't ready yet, but it will asynchronously
-                        // call `task.notify()` when it is ready.
-                        //
-                        // When that happens, the `notify` function will call
-                        // `execute_spawn` again.
-                        spawned.state.set( TaskState::Idle );
-                    }
-
-                } else {
-                    // This ensures that the Future will never be polled again.
-                    spawned.state.set( TaskState::Running );
-
-                    // The whole object might be deallocated at this point, so
-                    // it would be very dangerous to touch anything else.
-                    SpawnedTask::decrement_ref_count( spawned_ptr as usize );
-                }
+        // Take the future so that if we panic it gets dropped
+        if let Some(mut spawn_future) = spawn.take() {
+            if spawn_future.poll_future_notify( &&Core, self as *const _ as usize ) == Ok(Async::NotReady) {
+                // Future was not ready, so put it back
+                *spawn = Some(spawn_future);
             }
-
-            return;
         }
     }
 
-    unsafe fn notify( spawned_ptr: *const SpawnedTask ) {
-        let spawned = &*spawned_ptr;
-
-        // This causes it to re-run `poll` again, even if `task.notify()` was called inside of `poll`.
-        //
-        // IMPORTANT: If the Future calls `notify` multiple times within `poll`, it will only re-run
-        //            `poll` once!
-        let state = spawned.state.replace( TaskState::Queued );
-
-        // This only happens when `task.notify()` is called asynchronously.
-        if let TaskState::Idle = state {
-            SpawnedTask::execute_spawn( spawned_ptr );
-        }
-    }
-
-    unsafe fn increment_ref_count( id: usize ) -> usize {
-        let spawned_ptr = id as *const SpawnedTask;
-        let spawned = &*spawned_ptr;
-        let mut count = spawned.ref_count.get();
-        count += 1;
-        spawned.ref_count.set( count );
-        id
-    }
-
-    unsafe fn decrement_ref_count( id: usize ) {
-        let count = {
-            let spawned_ptr = id as *const SpawnedTask;
-            let spawned = &*spawned_ptr;
-            let mut count = spawned.ref_count.get();
-            count -= 1;
-            spawned.ref_count.set( count );
-            count
-        };
-
-        if count == 0 {
-            let spawned_ptr = id as *mut SpawnedTask;
-
-            // This causes the SpawnedTask to be dropped at the end of the scope.
-            let spawned = Box::from_raw( spawned_ptr );
-
-            // This ensures that the Future will never be polled again.
-            spawned.state.set( TaskState::Running );
+    fn notify( spawned: Rc<SpawnedTask> ) {
+        // If not already queued
+        if !spawned.is_queued.replace(true) {
+            // Poll on next micro-task
+            js! { @(no_return)
+                Promise.resolve().then(function() {
+                    @{ Once(move || spawned.poll()) }();
+                });
+            }
         }
     }
 }
-
-
-static CORE: &Core = &Core;
 
 struct Core;
 
 impl< F > Executor< F > for Core where
     F: Future< Item = (), Error = () > + 'static {
     fn execute( &self, future: F ) -> StdResult< (), ExecuteError< F > > {
-        let spawned_ptr = Box::into_raw( Box::new( SpawnedTask::new( future ) ) );
-
-        unsafe {
-            SpawnedTask::execute_spawn( spawned_ptr );
-        }
-
+        SpawnedTask::notify( SpawnedTask::new( future ) );
         Ok( () )
     }
 }
 
 impl Notify for Core {
     fn notify( &self, spawned_id: usize ) {
-        unsafe {
-            SpawnedTask::notify( spawned_id as *const SpawnedTask );
-        }
+        SpawnedTask::notify(unsafe { clone_raw(spawned_id as *const _) })
     }
 
     fn clone_id( &self, id: usize ) -> usize {
-        unsafe {
-            SpawnedTask::increment_ref_count( id )
-        }
+        unsafe { Rc::into_raw(clone_raw(id as *const SpawnedTask)) as usize }
     }
 
     fn drop_id( &self, id: usize ) {
-        unsafe {
-            SpawnedTask::decrement_ref_count( id );
-        }
+        unsafe { Rc::from_raw(id as *const SpawnedTask) };
     }
 }
 
@@ -184,5 +89,5 @@ impl Notify for Core {
 #[inline]
 pub fn spawn< F >( future: F ) where
     F: Future< Item = (), Error = () > + 'static {
-    CORE.execute( future ).unwrap();
+    Core.execute( future ).unwrap();
 }

--- a/src/webcore/promise_executor.rs
+++ b/src/webcore/promise_executor.rs
@@ -2,95 +2,112 @@ use futures::future::{Future, ExecuteError, Executor};
 use futures::executor::{self, Notify, Spawn};
 use futures::Async;
 use std::result::Result as StdResult;
-use std::rc::Rc;
 use std::cell::{Cell, RefCell};
-use Once;
 
+
+#[derive(Clone, Copy)]
+enum TaskState {
+    Idle,
+    Running,
+    Queued,
+}
 
 struct SpawnedTask {
-    is_alive: Rc< Cell< bool > >,
+    state: Cell< TaskState >,
     ref_count: Cell< usize >,
-    resubmission_count: Cell< usize >,
-    spawn: RefCell< Spawn< Box< Future<Item = (), Error = () > + 'static > > >,
+    spawn: RefCell< Spawn< Box< Future< Item = (), Error = () > + 'static > > >,
 }
 
 impl SpawnedTask {
     fn new< F >( future: F ) -> Self
         where F: Future< Item = (), Error = () > + 'static {
         Self {
-            is_alive: Rc::new( Cell::new( true ) ),
+            state: Cell::new( TaskState::Idle ),
             ref_count: Cell::new( 1 ),
-            resubmission_count: Cell::new( 0 ),
-            spawn: RefCell::new( executor::spawn( Box::new( future.fuse() )
-                as Box< Future<Item = (), Error = () > + 'static> ) ),
+            spawn: RefCell::new( executor::spawn(
+                Box::new( future ) as Box< Future< Item = (), Error = () > + 'static >
+            ) ),
         }
     }
 
+    // These are the situations that this algorithm needs to worry about:
+    //
+    //   execute -> poll
+    //   execute -> poll + poll
+    //   execute -> poll + notify -> repoll
+    //   execute -> poll + notify + notify -> repoll
+    //   execute -> poll + notify -> repoll -> async notify -> repoll
+    //   execute -> poll -> async notify -> repoll
+    //   execute -> poll -> async notify -> repoll + notify -> repoll
+    //   execute -> poll -> async notify -> repoll -> async notify -> repoll
+    //
     unsafe fn execute_spawn( spawned_ptr: *const SpawnedTask ) {
         let spawned = &*spawned_ptr;
 
-        // Queue up the task for execution.
-        spawned
-            .resubmission_count
-            .set( spawned.resubmission_count.get() + 1 );
+        loop {
+            // This is necessary because the Future might call `task.notify()` inside of `poll`.
+            // If that happens, we need to re-run `poll` again. So we use `state` to indicate
+            // whether we need to re-run `poll` or not.
+            spawned.state.set( TaskState::Running );
 
-        unsafe fn run( spawned_ptr: *const SpawnedTask ) {
-            let spawned = &*spawned_ptr;
-
-            // Here we try to take an execution token from the queue and execute
-            // the future. This may not be possible, as the future may already
-            // be executed somewhere higher up in the stack. We know there is at
-            // least one execution scheduled, so it's styled more like a
-            // do-while loop.
-
+            // Here we try to call `poll` on the future. This may not be possible,
+            // as the future may already be executed somewhere higher up in the stack.
+            // We know there is at least one execution scheduled, so it's styled more
+            // like a do-while loop.
+            //
             // The usage of the lock needs to be contained in a scope that is
             // separate from the decrement_ref_count, as that can deallocate the
             // whole spawned task, causing a segfault when the RefCell is trying
             // to release its borrow. That's why the poll_future_notify call is
             // contained inside the map.
-
             let result = spawned
                 .spawn
                 .try_borrow_mut()
                 .map( |mut s| s.poll_future_notify( &CORE, spawned_ptr as usize ) );
 
+            // TODO test this
             if let Ok( result ) = result {
-                // We were able to successfully execute the future, allowing us
-                // to dequeue one resubmission token.
-                spawned
-                    .resubmission_count
-                    .set( spawned.resubmission_count.get() - 1 );
-
                 if let Ok( Async::NotReady ) = result {
-                    // If there are more queued executions, then we execute them on the next event tick.
-                    // This is necessary because the Future might be waiting for an event on the event loop.
-                    if spawned.resubmission_count.get() != 0 {
-                        let is_alive = spawned.is_alive.clone();
+                    // The `poll` method called `task.notify()` so we have to re-run `poll` again.
+                    if let TaskState::Queued = spawned.state.get() {
+                        continue;
 
-                        let callback = move || {
-                            // Don't run the SpawnedTask if it's dropped
-                            if is_alive.get() {
-                                run( spawned_ptr );
-                            }
-                        };
-
-                        // TODO setTimeout isn't available in all JavaScript environments
-                        js! { @(no_return)
-                            setTimeout( function () {
-                                @{Once( callback )}();
-                            }, 0 );
-                        }
+                    } else {
+                        // The Future isn't ready yet, but it will asynchronously
+                        // call `task.notify()` when it is ready.
+                        //
+                        // When that happens, the `notify` function will call
+                        // `execute_spawn` again.
+                        spawned.state.set( TaskState::Idle );
                     }
 
                 } else {
+                    // This ensures that the Future will never be polled again.
+                    spawned.state.set( TaskState::Running );
+
                     // The whole object might be deallocated at this point, so
                     // it would be very dangerous to touch anything else.
                     SpawnedTask::decrement_ref_count( spawned_ptr as usize );
                 }
             }
-        }
 
-        run( spawned_ptr );
+            return;
+        }
+    }
+
+    unsafe fn notify( spawned_ptr: *const SpawnedTask ) {
+        let spawned = &*spawned_ptr;
+
+        // This causes it to re-run `poll` again, even if `task.notify()` was called inside of `poll`.
+        //
+        // IMPORTANT: If the Future calls `notify` multiple times within `poll`, it will only re-run
+        //            `poll` once!
+        let state = spawned.state.replace( TaskState::Queued );
+
+        // This only happens when `task.notify()` is called asynchronously.
+        if let TaskState::Idle = state {
+            SpawnedTask::execute_spawn( spawned_ptr );
+        }
     }
 
     unsafe fn increment_ref_count( id: usize ) -> usize {
@@ -115,10 +132,11 @@ impl SpawnedTask {
         if count == 0 {
             let spawned_ptr = id as *mut SpawnedTask;
 
-            // This causes the SpawnedTask to be dropped at the end of the scope
-            let task = Box::from_raw( spawned_ptr );
+            // This causes the SpawnedTask to be dropped at the end of the scope.
+            let spawned = Box::from_raw( spawned_ptr );
 
-            task.is_alive.set( false );
+            // This ensures that the Future will never be polled again.
+            spawned.state.set( TaskState::Running );
         }
     }
 }
@@ -143,10 +161,8 @@ impl< F > Executor< F > for Core where
 
 impl Notify for Core {
     fn notify( &self, spawned_id: usize ) {
-        let spawned_ptr = spawned_id as *const SpawnedTask;
-
         unsafe {
-            SpawnedTask::execute_spawn( spawned_ptr );
+            SpawnedTask::notify( spawned_id as *const SpawnedTask );
         }
     }
 
@@ -167,5 +183,5 @@ impl Notify for Core {
 #[inline]
 pub fn spawn< F >( future: F ) where
     F: Future< Item = (), Error = () > + 'static {
-    CORE.execute( future ).ok();
+    CORE.execute( future ).unwrap();
 }

--- a/src/webcore/promise_future.rs
+++ b/src/webcore/promise_future.rs
@@ -1,0 +1,118 @@
+use std;
+use webcore::value::{Value, ConversionError};
+use webcore::try_from::{TryInto, TryFrom};
+use futures::{Future, Poll, Async};
+use futures::unsync::oneshot::Receiver;
+use webcore::promise_executor::spawn;
+use super::promise::Promise;
+
+
+/// This allows you to use a JavaScript [`Promise`](struct.Promise.html) as if it is a Rust [`Future`](https://docs.rs/futures/0.1.18/futures/future/trait.Future.html).
+///
+/// The preferred way to create a `PromiseFuture` is to use [`value.try_into()`](unstable/trait.TryInto.html) on a JavaScript [`Value`](enum.Value.html).
+///
+/// # Examples
+///
+/// Convert a JavaScript `Promise` into a `PromiseFuture`:
+///
+/// ```rust
+/// use stdweb::PromiseFuture;
+/// use stdweb::web::error::Error;
+///
+/// let future: PromiseFuture<String, Error> = js!( return Promise.resolve("foo"); ).try_into().unwrap();
+/// ```
+pub struct PromiseFuture< A, B > {
+    pub(crate) future: Receiver< Result< A, B > >,
+}
+
+impl PromiseFuture< (), () > {
+    /// Asynchronously runs the [`Future`](https://docs.rs/futures/0.1.18/futures/future/trait.Future.html) and then immediately returns.
+    /// This does not block the current thread. The only way to retrieve the value of the future is to use the various
+    /// [`Future`](https://docs.rs/futures/0.1.18/futures/future/trait.Future.html) methods, such as
+    /// [`map`](https://docs.rs/futures/0.1.18/futures/future/trait.Future.html#method.map) or
+    /// [`inspect`](https://docs.rs/futures/0.1.18/futures/future/trait.Future.html#method.inspect).
+    ///
+    /// This function requires you to handle all errors yourself. Because the errors happen asynchronously, the only way to catch them is
+    /// to use a [`Future`](https://docs.rs/futures/0.1.18/futures/future/trait.Future.html) method, such as
+    /// [`map_err`](https://docs.rs/futures/0.1.18/futures/future/trait.Future.html#method.map_err).
+    ///
+    /// It is very common to want to print the errors to the console. You can do that by using `.map_err(|e| e.print())`
+    ///
+    /// This function is normally called once in `main`, it is usually not needed to call it multiple times.
+    ///
+    /// # Examples
+    ///
+    /// Asynchronously run a future in `main`, printing any errors to the console:
+    ///
+    /// ```rust
+    /// fn main() {
+    ///     PromiseFuture::spawn(
+    ///         create_some_future()
+    ///             .map_err(|e| e.print())
+    ///     );
+    /// }
+    /// ```
+    ///
+    /// Inspect the output value of the future:
+    ///
+    /// ```rust
+    /// fn main() {
+    ///     PromiseFuture::spawn(
+    ///         create_some_future()
+    ///             .inspect(|x| println!("Future finished: {:#?}", x))
+    ///             .map_err(|e| e.print())
+    ///     );
+    /// }
+    /// ```
+    ///
+    /// Catch errors and handle them yourself:
+    ///
+    /// ```rust
+    /// fn main() {
+    ///     PromiseFuture::spawn(
+    ///         create_some_future()
+    ///             .map_err(|e| handle_error_somehow(e))
+    ///     );
+    /// }
+    /// ```
+    #[inline]
+    pub fn spawn< B >( future: B ) where
+        B: Future< Item = (), Error = () > + 'static {
+        spawn( future );
+    }
+}
+
+impl< A, B > std::fmt::Debug for PromiseFuture< A, B > {
+    fn fmt( &self, formatter: &mut std::fmt::Formatter ) -> std::fmt::Result {
+        write!( formatter, "PromiseFuture" )
+    }
+}
+
+impl< A, B > Future for PromiseFuture< A, B > {
+    type Item = A;
+    type Error = B;
+
+    fn poll( &mut self ) -> Poll< Self::Item, Self::Error > {
+        // TODO maybe remove this unwrap ?
+        match self.future.poll().unwrap() {
+            Async::Ready( Ok( a ) ) => Ok( Async::Ready( a ) ),
+            Async::Ready( Err( e ) ) => Err( e ),
+            Async::NotReady => Ok( Async::NotReady ),
+        }
+    }
+}
+
+impl< A, B > TryFrom< Value > for PromiseFuture< A, B >
+    where A: TryFrom< Value > + 'static,
+          B: TryFrom< Value > + 'static,
+          // TODO remove this later
+          A::Error: std::fmt::Debug,
+          B::Error: std::fmt::Debug {
+
+    type Error = ConversionError;
+
+    fn try_from( v: Value ) -> Result< Self, Self::Error > {
+        let promise: Promise = v.try_into()?;
+        Ok( promise.to_future() )
+    }
+}


### PR DESCRIPTION
Fixes #72

@koute @CryZe This is untested and is definitely **not** ready to merge.

But I wanted to at least get started on adding in Promise support to stdweb. This pull request adds in the ability to convert any JS Promise into a Rustified Futurified version of that Promise. This conversion happens automatically with the `TryFrom<Value>` trait.

Please look this over and let me know if you see anything weird, or anything that can be improved.