### PR TITLE
Added WebGL Rendering Context

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ target
 Cargo.lock
 examples/*/target
 examples/*/Cargo.lock
+.idea/

--- a/examples/webgl/Cargo.toml
+++ b/examples/webgl/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "webgl"
+version = "0.1.0"
+authors = ["Liana Pigeot <liana.pigeot@gmail.com>"]
+
+[dependencies]
+stdweb = { path = "../.." }

--- a/examples/webgl/src/main.rs
+++ b/examples/webgl/src/main.rs
@@ -1,0 +1,26 @@
+extern crate stdweb;
+
+use stdweb::unstable::TryInto;
+use stdweb::web::{
+    IParentNode,
+    IHtmlElement,
+    document,
+    WebGLRenderingContext
+};
+
+use stdweb::web::html_element::CanvasElement;
+
+fn main() {
+    stdweb::initialize();
+
+    let canvas: CanvasElement = document().query_selector( "#canvas" ).unwrap().unwrap().try_into().unwrap();
+    let context: WebGLRenderingContext = canvas.get_context().unwrap();
+
+    canvas.set_width(canvas.offset_width() as u32);
+    canvas.set_height(canvas.offset_height() as u32);
+
+    context.clear_color(0.7, 0.2, 0.5, 1.0);
+    context.clear();
+
+    stdweb::event_loop();
+}

--- a/examples/webgl/static/index.html
+++ b/examples/webgl/static/index.html
@@ -1,0 +1,20 @@
+<!doctype html>
+<html lang="en">
+	<head>
+		<meta charset="utf-8">
+		<title>stdweb • Canvas</title>
+		<style>
+			html, body, canvas {
+				margin: 0px;
+				padding: 0px;
+				width: 100%;
+				height: 100%;
+				overflow: hidden;
+			}
+		</style>
+	</head>
+	<body>
+		<canvas id="canvas"></canvas>
+		<script src="js/app.js"></script>
+	</body>
+</html>

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -160,6 +160,7 @@ pub mod web {
     pub use webapi::history::History;
     pub use webapi::web_socket::{WebSocket, SocketCloseCode};
     pub use webapi::rendering_context::{RenderingContext, CanvasRenderingContext2d};
+    pub use webapi::webgl_rendering_context::WebGLRenderingContext;
     pub use webapi::mutation_observer::{MutationObserver, MutationObserverHandle, MutationObserverInit, MutationRecord};
     pub use webapi::xml_http_request::{XmlHttpRequest, XhrReadyState};
 

--- a/src/webapi/mod.rs
+++ b/src/webapi/mod.rs
@@ -27,6 +27,7 @@ pub mod xml_http_request;
 pub mod history;
 pub mod web_socket;
 pub mod rendering_context;
+pub mod webgl_rendering_context;
 pub mod mutation_observer;
 pub mod error;
 pub mod dom_exception;

--- a/src/webapi/webgl_rendering_context.rs
+++ b/src/webapi/webgl_rendering_context.rs
@@ -1,0 +1,45 @@
+use webcore::value::{Reference, ConversionError};
+use webcore::try_from::TryInto;
+use webapi::rendering_context::RenderingContext;
+use webapi::html_elements::CanvasElement;
+
+/// Used for drawing Webgl content onto the canvas element.
+///
+/// [(JavaScript docs)](https://developer.mozilla.org/en-US/docs/Web/API/WebGLRenderingContext)
+// https://html.spec.whatwg.org/#webglrenderingcontext
+pub struct WebGLRenderingContext(Reference);
+
+reference_boilerplate! {
+	WebGLRenderingContext,
+	instanceof WebGLRenderingContext
+}
+
+impl RenderingContext for WebGLRenderingContext {
+	type Error = ConversionError;
+	fn from_canvas(canvas: &CanvasElement) -> Result<Self, ConversionError> {
+		js!(
+			return @{canvas}.getContext("webgl");
+		).try_into()
+	}
+}
+	
+impl WebGLRenderingContext {
+	/// This specifies what color values to use when calling the clear() method.
+	/// The values are clamped between 0 and 1.
+	///
+	/// [(JavaScript docs)](https://developer.mozilla.org/en-US/docs/Web/API/WebGLRenderingContext/clearColor)
+	pub fn clear_color(&self, red: f64, green: f64, blue: f64, alpha: f64) {
+		js! { @(no_return)
+			@{&self.0}.clearColor(@{red}, @{green}, @{blue}, @{alpha});
+		}
+	}
+
+	/// The WebGLRenderingContext.clear() method of the WebGL API clears buffers to preset values.
+	///
+	/// [(JavaScript docs)](https://developer.mozilla.org/en-US/docs/Web/API/WebGLRenderingContext/clear)
+	pub fn clear(&self) {
+		js! { @(no_return)
+			@{&self.0}.clear(@{&self.0}.COLOR_BUFFER_BIT);
+		}
+	}
+}


### PR DESCRIPTION
First time writing Rust, sorry if I did something wrong

* Added basic `WebGLRenderingContext` with two functions as proof of concept
* It's in a separate file to not pollute the `RenderingContext` file (and I would advise moving the 2d context out of that file too)
* Added an example similar to the canvas one (it just draws a color on screen)

Also added .idea files to `.gitignore` to not commit project files.