### PR TITLE
Add some window size properties

### DIFF
--- a/src/webapi/window.rs
+++ b/src/webapi/window.rs
@@ -1,4 +1,5 @@
 use webcore::value::Reference;
+use webcore::try_from::TryInto;
 use webapi::event_target::{IEventTarget, EventTarget};
 use webapi::window_or_worker::IWindowOrWorker;
 use webapi::storage::Storage;
@@ -142,5 +143,51 @@ impl Window {
                 return @{self}.history;
             ).into_reference_unchecked().unwrap()
         }
+    }
+
+    /// Returns the width (in pixels) of the browser window viewport including, if rendered,
+    /// the vertical scrollbar.
+    ///
+    /// [(JavaScript docs)](https://developer.mozilla.org/en-US/docs/Web/API/window/innerWidth)
+    // https://drafts.csswg.org/cssom-view/#ref-for-dom-window-innerwidth
+    pub fn inner_width(&self) -> i32 {
+        js!(
+            return @{self}.innerWidth;
+        ).try_into().unwrap()
+    }
+
+    /// Returns the height (in pixels) of the browser window viewport including, if rendered,
+    /// the horizontal scrollbar.
+    ///
+    /// [(JavaScript docs)](https://developer.mozilla.org/en-US/docs/Web/API/window/innerHeight)
+    // https://drafts.csswg.org/cssom-view/#ref-for-dom-window-innerheight
+    pub fn inner_height(&self) -> i32 {
+        js!(
+            return @{self}.innerHeight;
+        ).try_into().unwrap()
+    }
+
+    /// Returns the width of the outside of the browser window. It represents the width
+    /// of the whole browser window including sidebar (if expanded), window chrome
+    /// and window resizing borders/handles.
+    ///
+    /// [(JavaScript docs)](https://developer.mozilla.org/en-US/docs/Web/API/Window/outerWidth)
+    // https://drafts.csswg.org/cssom-view/#ref-for-dom-window-outerheight
+    pub fn outer_width(&self) -> i32 {
+        js!(
+            return @{self}.outerWidth;
+        ).try_into().unwrap()
+    }
+
+    /// Returns the height of the outside of the browser window. It represents the height
+    /// of the whole browser window including sidebar (if expanded), window chrome
+    /// and window resizing borders/handles.
+    ///
+    /// [(JavaScript docs)](https://developer.mozilla.org/en-US/docs/Web/API/Window/outerHeight)
+    // https://drafts.csswg.org/cssom-view/#ref-for-dom-window-outerheight
+    pub fn outer_height(&self) -> i32 {
+        js!(
+            return @{self}.outerHeight;
+        ).try_into().unwrap()
     }
 }


### PR DESCRIPTION
For keeping a canvas in sync with the window size in [dubni](https://github.com/JulianKniephoff/dubni), we (the two developers, not the royal we :wink:) use the `window.innerWidth` and `window.innerHeight` properties.

Currently we have to use a `js!`-block; this PR exposes the necessary functions.

Please let me know if I missed something or can improve anything! :smiley: