### PR TITLE
Add various console macros and removing the Error::print method

### DIFF
--- a/examples/promise/src/main.rs
+++ b/examples/promise/src/main.rs
@@ -17,7 +17,7 @@ fn test_from_thenable() {
 
     a.unwrap().done( |result: Result< u32, u32 > | {
         assert_eq!( result, Ok( 5 ) );
-        console_log!( format!( "Thenable 1: {:#?}", result ) );
+        console!( log, format!( "Thenable 1: {:#?}", result ) );
     } );
 
 
@@ -25,7 +25,7 @@ fn test_from_thenable() {
 
     a.unwrap().done( |result: Result< u32, u32 > | {
         assert_eq!( result, Ok( 1 ) );
-        console_log!( format!( "Thenable 2: {:#?}", result ) );
+        console!( log, format!( "Thenable 2: {:#?}", result ) );
     } );
 
 
@@ -40,18 +40,18 @@ fn test_error_conversion() {
 
     PromiseFuture::spawn(
         a.map( |_| () ).map_err( |x| {
-            console_log!( "String error:", x );
+            console!( log, "String error:", x );
         } )
     );
 
     let _a: PromiseFuture< Null > = js!( return Promise.resolve( null ); ).try_into().unwrap();
-    console_log!( "Null works" );
+    console!( log, "Null works" );
 
     let _a: PromiseFuture< Null > = js!( return Promise.reject( new Error( "hi!" ) ); ).try_into().unwrap();
-    console_log!( "Error works" );
+    console!( log, "Error works" );
 
     //let _a: PromiseFuture< Null, SyntaxError > = js!( return Promise.reject( new Error( "hi!" ) ); ).try_into().unwrap();
-    //console_log!( "Error conversion fails" );
+    //console!( log, "Error conversion fails" );
 }
 
 
@@ -66,15 +66,15 @@ fn test_refcell() {
         type Error = ();
 
         fn poll(&mut self) -> Poll<Self::Item, Self::Error> {
-            console_log!("Poll TaskA");
+            console!( log, "Poll TaskA" );
 
             let foo = self.shared_state.borrow_mut();
 
-            console_log!(format!("TaskA 1: {:#?}", foo));
+            console!( log, format!("TaskA 1: {:#?}", foo) );
 
             self.task_b.notify();
 
-            console_log!(format!("TaskA 2: {:#?}", foo));
+            console!( log, format!("TaskA 2: {:#?}", foo) );
 
             Ok(Async::NotReady)
         }
@@ -90,7 +90,7 @@ fn test_refcell() {
         type Error = ();
 
         fn poll(&mut self) -> Poll<Self::Item, Self::Error> {
-            console_log!("Poll TaskB");
+            console!( log, "Poll TaskB" );
 
             if !self.initialized {
                 self.initialized = true;
@@ -99,7 +99,7 @@ fn test_refcell() {
 
                 let foo = self.shared_state.borrow();
 
-                console_log!(format!("TaskB 1: {:#?}", foo));
+                console!( log, format!("TaskB 1: {:#?}", foo) );
 
                 PromiseFuture::spawn(TaskA {
                     shared_state: self.shared_state.clone(),
@@ -109,7 +109,7 @@ fn test_refcell() {
 
             let foo = self.shared_state.borrow();
 
-            console_log!(format!("TaskB 1: {:#?}", foo));
+            console!( log, format!("TaskB 1: {:#?}", foo) );
 
             Ok(Async::NotReady)
         }
@@ -126,7 +126,7 @@ fn test_panic() {
     let promise: Promise = js!( return Promise.resolve(null); ).try_into().unwrap();
 
     promise.done( |result: Result< Null, Error >| {
-        console_log!( format!( "Promise result: {:#?}", result ) );
+        console!( log, format!( "Promise result: {:#?}", result ) );
         panic!( "Testing panic!" );
     } );
 }
@@ -145,12 +145,12 @@ fn test_notify() {
             let ( sender, receiver ) = futures::unsync::oneshot::channel();
 
             let callback = || {
-                console_log!( "setTimeout done" );
+                console!( log, "setTimeout done" );
 
-                console_log!( format!("Sending {:#?}", sender.send( () ) ) );
+                console!( log, format!("Sending {:#?}", sender.send( () ) ) );
             };
 
-            console_log!( "setTimeout started" );
+            console!( log, "setTimeout started" );
 
             js! { @(no_return)
                 setTimeout( function () {
@@ -218,7 +218,7 @@ fn test_notify() {
 
     PromiseFuture::spawn(
         MyFuture::new( 5 ).map( |x| {
-            console_log!( format!( "MyFuture count: {}", x ) );
+            console!( log, format!( "MyFuture count: {}", x ) );
             assert_eq!( x, 7 );
         } )
     );
@@ -235,13 +235,13 @@ fn test_timeout() {
     }
 
     PromiseFuture::spawn(
-        sleep( 2000 ).inspect( |_| console_log!( "Timeout 1 done!" ) ).join(
-        sleep( 2000 ).inspect( |_| console_log!( "Timeout 2 done!" ) ) )
+        sleep( 2000 ).inspect( |_| console!( log, "Timeout 1 done!" ) ).join(
+        sleep( 2000 ).inspect( |_| console!( log, "Timeout 2 done!" ) ) )
             .and_then( |_|
-                sleep( 1000 ).inspect( |_| console_log!( "Timeout 3 done!" ) ) )
+                sleep( 1000 ).inspect( |_| console!( log, "Timeout 3 done!" ) ) )
             .and_then( |_|
                 futures::future::err( Error::new( "Testing error!" ) ) )
-            .map_err( |e| console_error!( e ) )
+            .map_err( |e| console!( error, e ) )
     );
 }
 
@@ -258,4 +258,3 @@ fn main() {
 
     stdweb::event_loop();
 }
-

--- a/examples/promise/src/main.rs
+++ b/examples/promise/src/main.rs
@@ -241,7 +241,7 @@ fn test_timeout() {
                 sleep( 1000 ).inspect( |_| console_log!( "Timeout 3 done!" ) ) )
             .and_then( |_|
                 futures::future::err( Error::new( "Testing error!" ) ) )
-            .map_err( |e| e.print() )
+            .map_err( |e| console_error!( e ) )
     );
 }
 

--- a/src/webapi/console.rs
+++ b/src/webapi/console.rs
@@ -1,0 +1,46 @@
+#[doc(hidden)]
+#[macro_export]
+macro_rules! js_call {
+	( $f:expr, $( $args:expr ),* ) => {{
+    	js! { @(no_return)
+    		$f( $( @{$args} ),* );
+    	}
+    	()
+    }};
+}
+
+
+#[macro_export]
+macro_rules! console_clear {
+    () => {
+    	js_call!( console.clear, );
+    };
+}
+
+#[macro_export]
+macro_rules! console_log {
+    ( $( $args:expr ),* ) => {
+    	js_call!( console.log, $( $args ),* );
+    };
+}
+
+#[macro_export]
+macro_rules! console_error {
+    ( $( $args:expr ),* ) => {
+    	js_call!( console.error, $( $args ),* );
+    };
+}
+
+#[macro_export]
+macro_rules! console_debug {
+    ( $( $args:expr ),* ) => {
+    	js_call!( console.debug, $( $args ),* );
+    };
+}
+
+#[macro_export]
+macro_rules! console_info {
+    ( $( $args:expr ),* ) => {
+    	js_call!( console.info, $( $args ),* );
+    };
+}

--- a/src/webapi/console.rs
+++ b/src/webapi/console.rs
@@ -1,141 +1,67 @@
-#[doc(hidden)]
-#[macro_export]
-macro_rules! js_call {
-    ( $f:expr, $( $args:expr ),* ) => {{
-        js! { @(no_return)
-            $f( $( @{$args} ),* );
-        }
-        ()
-    }};
-}
-
-
-/// Clears the console.
+/// Calls methods on the JavaScript `console` object.
 ///
-/// If it cannot clear the console then it does nothing.
+/// This should **only** be used for debugging purposes, its behavior is
+/// **not** standardized: it **will** vary with different browsers
+/// and Node.js.
+///
+/// The first argument is the name of the `console` method.
+///
+/// The remaining arguments can be anything which can be sent to JavaScript,
+/// and they do not need to be the same type.
+///
+/// If you want to print things to the console in a standardized way, use
+/// [`println!`](https://doc.rust-lang.org/std/macro.println.html) instead.
+///
+/// [(JavaScript docs)](https://developer.mozilla.org/en-US/docs/Web/API/console)
 ///
 /// # Examples
 ///
+/// ## clear
+///
+/// Clear the console:
+///
 /// ```rust
-/// console_clear!();
+/// console!(clear);
 /// ```
 ///
 /// [(JavaScript docs)](https://developer.mozilla.org/en-US/docs/Web/API/Console/clear)
-#[macro_export]
-macro_rules! console_clear {
-    () => {
-        js_call!( console.clear, );
-    };
-}
-
-
-/// Prints zero or more values to the console.
 ///
-/// The values can be anything that can be sent to JavaScript, and they do not
-/// need to be the same type.
-///
-/// Usually it will print a space in between each value, and it will always print
-/// a newline at the end.
-///
-/// However, this is *not guaranteed*, the printing behavior **will** vary between
-/// different browsers and Node.js, therefore you should use `console_log` *only*
-/// for debugging purposes.
-///
-/// If the first value is a string, then you can use string substitutions to
-/// control how the remaining values are printed. Please see [this site](https://developer.mozilla.org/en-US/docs/Web/API/console#Using_string_substitutions)
-/// for more information about string substitutions.
-///
-/// # Examples
+/// ## log
 ///
 /// Print a newline:
 ///
 /// ```rust
-/// console_log!("");
+/// console!(log, "");
 /// ```
 ///
 /// Print one value:
 ///
 /// ```rust
-/// console_log!("Hello world!");
+/// console!(log, "Hello world!");
 /// ```
 ///
 /// Print more than one value:
 ///
 /// ```rust
-/// console_log!(1, "test", vec![2, 3]);
+/// console!(log, 1, "test", vec![2, 3]);
 /// ```
 ///
-/// Print more than one value with Rust's formatting:
-///
-/// ```rust
-/// console_log!(format!("{:#?} {:#?} {:#?}", 1, "test", vec![2, 3]));
-/// ```
-///
-/// Use string substitution to control how the values are printed:
-///
-/// ```rust
-/// console_log!("foo: %s bar: %s", vec![1, 2], vec![3, 4]);
-/// ```
+/// All of the `log` examples also work with `error`, `debug`, `info`, and `warn`.
 ///
 /// [(JavaScript docs)](https://developer.mozilla.org/en-US/docs/Web/API/Console/log)
 #[macro_export]
-macro_rules! console_log {
-    ( $( $args:expr ),* ) => {
-        js_call!( console.log, $( $args ),* );
-    };
-}
+macro_rules! console {
+    ( $name:ident ) => {{
+        js! { @(no_return)
+            console.$name();
+        }
+        ()
+    }};
 
-
-/// Prints zero or more values to the console.
-///
-/// This is exactly the same as [`console_log`](macro.console_log.html), except that it prints a special "error" message.
-///
-/// [(JavaScript docs)](https://developer.mozilla.org/en-US/docs/Web/API/Console/error)
-#[macro_export]
-macro_rules! console_error {
-    ( $( $args:expr ),* ) => {
-        js_call!( console.error, $( $args ),* );
-    };
-}
-
-
-/// Prints zero or more values to the console.
-///
-/// This is exactly the same as [`console_log`](macro.console_log.html), except that it prints a special "debug" message.
-///
-/// In some JavaScript environments it won't print anything at all, so do not use it
-/// for anything other than debugging.
-///
-/// [(JavaScript docs)](https://developer.mozilla.org/en-US/docs/Web/API/Console/debug)
-#[macro_export]
-macro_rules! console_debug {
-    ( $( $args:expr ),* ) => {
-        js_call!( console.debug, $( $args ),* );
-    };
-}
-
-
-/// Prints zero or more values to the console.
-///
-/// This is exactly the same as [`console_log`](macro.console_log.html), except that it prints a special "info" message.
-///
-/// [(JavaScript docs)](https://developer.mozilla.org/en-US/docs/Web/API/Console/info)
-#[macro_export]
-macro_rules! console_info {
-    ( $( $args:expr ),* ) => {
-        js_call!( console.info, $( $args ),* );
-    };
-}
-
-
-/// Prints zero or more values to the console.
-///
-/// This is exactly the same as [`console_log`](macro.console_log.html), except that it prints a special "warn" message.
-///
-/// [(JavaScript docs)](https://developer.mozilla.org/en-US/docs/Web/API/Console/warn)
-#[macro_export]
-macro_rules! console_warn {
-    ( $( $args:expr ),* ) => {
-        js_call!( console.warn, $( $args ),* );
-    };
+    ( $name:ident, $( $args:expr ),* ) => {{
+        js! { @(no_return)
+            console.$name( $( @{$args} ),* );
+        }
+        ()
+    }};
 }

--- a/src/webapi/console.rs
+++ b/src/webapi/console.rs
@@ -126,3 +126,16 @@ macro_rules! console_info {
     	js_call!( console.info, $( $args ),* );
     };
 }
+
+
+/// Prints zero or more values to the console.
+///
+/// This is exactly the same as [`console_log`](macro.console_log.html), except that it prints a special "warn" message.
+///
+/// [(JavaScript docs)](https://developer.mozilla.org/en-US/docs/Web/API/Console/warn)
+#[macro_export]
+macro_rules! console_warn {
+    ( $( $args:expr ),* ) => {
+    	js_call!( console.warn, $( $args ),* );
+    };
+}

--- a/src/webapi/console.rs
+++ b/src/webapi/console.rs
@@ -1,3 +1,22 @@
+#[doc(hidden)]
+#[macro_export]
+macro_rules! console_unsafe {
+    ( $name:ident ) => {{
+        js! { @(no_return)
+            console.$name();
+        }
+        ()
+    }};
+
+    ( $name:ident, $( $args:expr ),* ) => {{
+        js! { @(no_return)
+            console.$name( $( @{$args} ),* );
+        }
+        ()
+    }};
+}
+
+
 /// Calls methods on the JavaScript `console` object.
 ///
 /// This should **only** be used for debugging purposes, its behavior is
@@ -15,16 +34,6 @@
 /// [(JavaScript docs)](https://developer.mozilla.org/en-US/docs/Web/API/console)
 ///
 /// # Examples
-///
-/// ## clear
-///
-/// Clear the console:
-///
-/// ```rust
-/// console!(clear);
-/// ```
-///
-/// [(JavaScript docs)](https://developer.mozilla.org/en-US/docs/Web/API/Console/clear)
 ///
 /// ## log
 ///
@@ -46,22 +55,21 @@
 /// console!(log, 1, "test", vec![2, 3]);
 /// ```
 ///
-/// All of the `log` examples also work with `error`, `debug`, `info`, and `warn`.
+/// Use [string substitution](https://developer.mozilla.org/en-US/docs/Web/API/console#Using_string_substitutions) to control how the values are printed:
+///
+/// ```rust
+/// console!(log, "foo: %s bar: %s", vec![1, 2], vec![3, 4]);
+/// ```
 ///
 /// [(JavaScript docs)](https://developer.mozilla.org/en-US/docs/Web/API/Console/log)
+///
+/// ## error
+///
+/// This is exactly the same as `log`, except it prints an error message rather than a normal message.
+///
+/// [(JavaScript docs)](https://developer.mozilla.org/en-US/docs/Web/API/Console/error)
 #[macro_export]
 macro_rules! console {
-    ( $name:ident ) => {{
-        js! { @(no_return)
-            console.$name();
-        }
-        ()
-    }};
-
-    ( $name:ident, $( $args:expr ),* ) => {{
-        js! { @(no_return)
-            console.$name( $( @{$args} ),* );
-        }
-        ()
-    }};
+    ( log, $( $args:expr ),+ ) => { console_unsafe!( log, $( $args ),+ ) };
+    ( error, $( $args:expr ),+ ) => { console_unsafe!( error, $( $args ),+ ) };
 }

--- a/src/webapi/console.rs
+++ b/src/webapi/console.rs
@@ -1,11 +1,11 @@
 #[doc(hidden)]
 #[macro_export]
 macro_rules! js_call {
-	( $f:expr, $( $args:expr ),* ) => {{
-    	js! { @(no_return)
-    		$f( $( @{$args} ),* );
-    	}
-    	()
+    ( $f:expr, $( $args:expr ),* ) => {{
+        js! { @(no_return)
+            $f( $( @{$args} ),* );
+        }
+        ()
     }};
 }
 
@@ -24,7 +24,7 @@ macro_rules! js_call {
 #[macro_export]
 macro_rules! console_clear {
     () => {
-    	js_call!( console.clear, );
+        js_call!( console.clear, );
     };
 }
 
@@ -81,7 +81,7 @@ macro_rules! console_clear {
 #[macro_export]
 macro_rules! console_log {
     ( $( $args:expr ),* ) => {
-    	js_call!( console.log, $( $args ),* );
+        js_call!( console.log, $( $args ),* );
     };
 }
 
@@ -94,7 +94,7 @@ macro_rules! console_log {
 #[macro_export]
 macro_rules! console_error {
     ( $( $args:expr ),* ) => {
-    	js_call!( console.error, $( $args ),* );
+        js_call!( console.error, $( $args ),* );
     };
 }
 
@@ -110,7 +110,7 @@ macro_rules! console_error {
 #[macro_export]
 macro_rules! console_debug {
     ( $( $args:expr ),* ) => {
-    	js_call!( console.debug, $( $args ),* );
+        js_call!( console.debug, $( $args ),* );
     };
 }
 
@@ -123,7 +123,7 @@ macro_rules! console_debug {
 #[macro_export]
 macro_rules! console_info {
     ( $( $args:expr ),* ) => {
-    	js_call!( console.info, $( $args ),* );
+        js_call!( console.info, $( $args ),* );
     };
 }
 
@@ -136,6 +136,6 @@ macro_rules! console_info {
 #[macro_export]
 macro_rules! console_warn {
     ( $( $args:expr ),* ) => {
-    	js_call!( console.warn, $( $args ),* );
+        js_call!( console.warn, $( $args ),* );
     };
 }

--- a/src/webapi/console.rs
+++ b/src/webapi/console.rs
@@ -1,6 +1,6 @@
 #[doc(hidden)]
 #[macro_export]
-macro_rules! console_unsafe {
+macro_rules! __internal_console_unsafe {
     ( $name:ident ) => {{
         js! { @(no_return)
             console.$name();
@@ -70,6 +70,6 @@ macro_rules! console_unsafe {
 /// [(JavaScript docs)](https://developer.mozilla.org/en-US/docs/Web/API/Console/error)
 #[macro_export]
 macro_rules! console {
-    ( log, $( $args:expr ),+ ) => { console_unsafe!( log, $( $args ),+ ) };
-    ( error, $( $args:expr ),+ ) => { console_unsafe!( error, $( $args ),+ ) };
+    ( log, $( $args:expr ),+ ) => { __internal_console_unsafe!( log, $( $args ),+ ) };
+    ( error, $( $args:expr ),+ ) => { __internal_console_unsafe!( error, $( $args ),+ ) };
 }

--- a/src/webapi/console.rs
+++ b/src/webapi/console.rs
@@ -10,6 +10,17 @@ macro_rules! js_call {
 }
 
 
+/// Clears the console.
+///
+/// If it cannot clear the console then it does nothing.
+///
+/// # Examples
+///
+/// ```rust
+/// console_clear!();
+/// ```
+///
+/// [(JavaScript docs)](https://developer.mozilla.org/en-US/docs/Web/API/Console/clear)
 #[macro_export]
 macro_rules! console_clear {
     () => {
@@ -17,6 +28,56 @@ macro_rules! console_clear {
     };
 }
 
+
+/// Prints zero or more values to the console.
+///
+/// The values can be anything that can be sent to JavaScript, and they do not
+/// need to be the same type.
+///
+/// Usually it will print a space in between each value, and it will always print
+/// a newline at the end.
+///
+/// However, this is *not guaranteed*, the printing behavior **will** vary between
+/// different browsers and Node.js, therefore you should use `console_log` *only*
+/// for debugging purposes.
+///
+/// If the first value is a string, then you can use string substitutions to
+/// control how the remaining values are printed. Please see [this site](https://developer.mozilla.org/en-US/docs/Web/API/console#Using_string_substitutions)
+/// for more information about string substitutions.
+///
+/// # Examples
+///
+/// Print a newline:
+///
+/// ```rust
+/// console_log!("");
+/// ```
+///
+/// Print one value:
+///
+/// ```rust
+/// console_log!("Hello world!");
+/// ```
+///
+/// Print more than one value:
+///
+/// ```rust
+/// console_log!(1, "test", vec![2, 3]);
+/// ```
+///
+/// Print more than one value with Rust's formatting:
+///
+/// ```rust
+/// console_log!(format!("{:#?} {:#?} {:#?}", 1, "test", vec![2, 3]));
+/// ```
+///
+/// Use string substitution to control how the values are printed:
+///
+/// ```rust
+/// console_log!("foo: %s bar: %s", vec![1, 2], vec![3, 4]);
+/// ```
+///
+/// [(JavaScript docs)](https://developer.mozilla.org/en-US/docs/Web/API/Console/log)
 #[macro_export]
 macro_rules! console_log {
     ( $( $args:expr ),* ) => {
@@ -24,6 +85,12 @@ macro_rules! console_log {
     };
 }
 
+
+/// Prints zero or more values to the console.
+///
+/// This is exactly the same as [`console_log`](macro.console_log.html), except that it prints a special "error" message.
+///
+/// [(JavaScript docs)](https://developer.mozilla.org/en-US/docs/Web/API/Console/error)
 #[macro_export]
 macro_rules! console_error {
     ( $( $args:expr ),* ) => {
@@ -31,6 +98,15 @@ macro_rules! console_error {
     };
 }
 
+
+/// Prints zero or more values to the console.
+///
+/// This is exactly the same as [`console_log`](macro.console_log.html), except that it prints a special "debug" message.
+///
+/// In some JavaScript environments it won't print anything at all, so do not use it
+/// for anything other than debugging.
+///
+/// [(JavaScript docs)](https://developer.mozilla.org/en-US/docs/Web/API/Console/debug)
 #[macro_export]
 macro_rules! console_debug {
     ( $( $args:expr ),* ) => {
@@ -38,6 +114,12 @@ macro_rules! console_debug {
     };
 }
 
+
+/// Prints zero or more values to the console.
+///
+/// This is exactly the same as [`console_log`](macro.console_log.html), except that it prints a special "info" message.
+///
+/// [(JavaScript docs)](https://developer.mozilla.org/en-US/docs/Web/API/Console/info)
 #[macro_export]
 macro_rules! console_info {
     ( $( $args:expr ),* ) => {

--- a/src/webapi/error.rs
+++ b/src/webapi/error.rs
@@ -48,16 +48,6 @@ impl Error {
     pub fn new( description: &str ) -> Self {
         js!( return new Error( @{description} ); ).try_into().unwrap()
     }
-
-    /// Prints the `Error` to the console (this prints the error's description and also its stack trace).
-    ///
-    /// [(JavaScript docs)](https://developer.mozilla.org/en-US/docs/Web/API/Console/error)
-    #[inline]
-    pub fn print( &self ) {
-        js! { @(no_return)
-            console.error( @{self} );
-        }
-    }
 }
 
 impl IError for Error {}

--- a/src/webapi/mod.rs
+++ b/src/webapi/mod.rs
@@ -32,3 +32,4 @@ pub mod error;
 pub mod dom_exception;
 pub mod events;
 pub mod parent_node;
+pub mod console;

--- a/src/webcore/promise_future.rs
+++ b/src/webcore/promise_future.rs
@@ -34,7 +34,7 @@ impl PromiseFuture< (), () > {
     /// to use a [`Future`](https://docs.rs/futures/0.1.18/futures/future/trait.Future.html) method, such as
     /// [`map_err`](https://docs.rs/futures/0.1.18/futures/future/trait.Future.html#method.map_err).
     ///
-    /// It is very common to want to print the errors to the console. You can do that by using `.map_err(|e| e.print())`
+    /// It is very common to want to print the errors to the console. You can do that by using `.map_err(|e| console_error!(e))`
     ///
     /// This function is normally called once in `main`, it is usually not needed to call it multiple times.
     ///
@@ -46,7 +46,7 @@ impl PromiseFuture< (), () > {
     /// fn main() {
     ///     PromiseFuture::spawn(
     ///         create_some_future()
-    ///             .map_err(|e| e.print())
+    ///             .map_err(|e| console_error!(e))
     ///     );
     /// }
     /// ```
@@ -58,7 +58,7 @@ impl PromiseFuture< (), () > {
     ///     PromiseFuture::spawn(
     ///         create_some_future()
     ///             .inspect(|x| println!("Future finished: {:#?}", x))
-    ///             .map_err(|e| e.print())
+    ///             .map_err(|e| console_error!(e))
     ///     );
     /// }
     /// ```

--- a/src/webcore/promise_future.rs
+++ b/src/webcore/promise_future.rs
@@ -34,7 +34,7 @@ impl PromiseFuture< (), () > {
     /// to use a [`Future`](https://docs.rs/futures/0.1.18/futures/future/trait.Future.html) method, such as
     /// [`map_err`](https://docs.rs/futures/0.1.18/futures/future/trait.Future.html#method.map_err).
     ///
-    /// It is very common to want to print the errors to the console. You can do that by using `.map_err(|e| console_error!(e))`
+    /// It is very common to want to print the errors to the console. You can do that by using `.map_err(|e| console!(error, e))`
     ///
     /// This function is normally called once in `main`, it is usually not needed to call it multiple times.
     ///
@@ -46,7 +46,7 @@ impl PromiseFuture< (), () > {
     /// fn main() {
     ///     PromiseFuture::spawn(
     ///         create_some_future()
-    ///             .map_err(|e| console_error!(e))
+    ///             .map_err(|e| console!(error, e))
     ///     );
     /// }
     /// ```
@@ -58,7 +58,7 @@ impl PromiseFuture< (), () > {
     ///     PromiseFuture::spawn(
     ///         create_some_future()
     ///             .inspect(|x| println!("Future finished: {:#?}", x))
-    ///             .map_err(|e| console_error!(e))
+    ///             .map_err(|e| console!(error, e))
     ///     );
     /// }
     /// ```


### PR DESCRIPTION
Fixes #55 

The reason why they are macros and not functions is because browsers can display objects in a special way (e.g. you can click on the arrow to expand the object's properties, etc.)

However, this only works if you pass in the object directly, so serializing to a string would prevent that.

I *could* make them functions with a type signature like `fn log<A>(input: A)`, but that limits it to a single argument. Using a macro lets it work with an unlimited number of arguments.