### PR TITLE
Adding in TryFrom<Value> for ()

### DIFF
--- a/src/webcore/value.rs
+++ b/src/webcore/value.rs
@@ -860,6 +860,18 @@ impl TryFrom< Value > for Null {
     }
 }
 
+impl TryFrom< Value > for () {
+    type Error = ConversionError;
+
+    #[inline]
+    fn try_from( value: Value ) -> Result< Self, Self::Error > {
+        match value {
+            Value::Null | Value::Undefined => Ok( () ),
+            _ => Err( ConversionError::type_mismatch( &value ) )
+        }
+    }
+}
+
 impl TryFrom< Value > for bool {
     type Error = ConversionError;
 
@@ -1200,5 +1212,17 @@ mod tests {
 
         let typed_reference: Result< TypeError, _ > = reference.try_into();
         assert!( typed_reference.is_err() );
+    }
+
+    #[test]
+    fn convert_from_null_or_undefined_to_empty_tuple() {
+        let a: Result< (), _ > = js! { return null; }.try_into();
+        assert!( a.is_ok() );
+
+        let a: Result< (), _ > = js! { return undefined; }.try_into();
+        assert!( a.is_ok() );
+
+        let a: Result< (), _ > = js! { return 1; }.try_into();
+        assert!( a.is_err() );
     }
 }


### PR DESCRIPTION
This adds in the ability to convert JavaScript `null` or `undefined` into Rust `()`

This is useful in general, but it's *especially* useful with Promises. It's common to have Promises that are called purely for side effects, so they have a value of `null` or `undefined`. In Rust it is idiomatic to use `()` for Futures that don't have side effects.

This pull request adds in the ability to do things like this:

```rust
fn wait( ms: u32 ) -> PromiseFuture< (), Error > {
    js! {
        return new Promise( function ( success, error ) {
            setTimeout( function () {
                success();
            }, @{ms} );
        } );
    }.try_into().unwrap()
}
```

Without this pull request, it's... a lot harder. You would have to `map` the `PromiseFuture` to convert `Undefined` into `()`, but because `impl Future` syntax isn't in stable yet, you are forced to `Box` the return value, which is pretty bad.