### PR TITLE
Adding in timer Futures (e.g. setTimeout and setInterval)

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -203,7 +203,7 @@ pub mod serde {
 
 /// A module with bindings to the Web APIs.
 pub mod web {
-    #[cfg(feature = "futures")]
+    #[cfg(feature = "futures-support")]
     pub use webapi::timer_future::{
         Wait,
         wait,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -203,6 +203,12 @@ pub mod serde {
 
 /// A module with bindings to the Web APIs.
 pub mod web {
+    #[cfg(feature = "futures")]
+    pub use webapi::timer_future::{
+        TimerFuture,
+        wait
+    };
+
     pub use webapi::window::{
         Window,
         window

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -206,7 +206,9 @@ pub mod web {
     #[cfg(feature = "futures")]
     pub use webapi::timer_future::{
         Wait,
-        wait
+        wait,
+        IntervalBuffered,
+        interval_buffered
     };
 
     pub use webapi::window::{

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -205,7 +205,7 @@ pub mod serde {
 pub mod web {
     #[cfg(feature = "futures")]
     pub use webapi::timer_future::{
-        TimerFuture,
+        WaitFuture,
         wait
     };
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -205,7 +205,7 @@ pub mod serde {
 pub mod web {
     #[cfg(feature = "futures")]
     pub use webapi::timer_future::{
-        WaitFuture,
+        Wait,
         wait
     };
 

--- a/src/webapi/mod.rs
+++ b/src/webapi/mod.rs
@@ -39,5 +39,5 @@ pub mod html_collection;
 pub mod child_node;
 pub mod gamepad;
 
-#[cfg(feature = "futures")]
+#[cfg(feature = "futures-support")]
 pub mod timer_future;

--- a/src/webapi/mod.rs
+++ b/src/webapi/mod.rs
@@ -38,3 +38,6 @@ pub mod console;
 pub mod html_collection;
 pub mod child_node;
 pub mod gamepad;
+
+#[cfg(feature = "futures")]
+pub mod timer_future;

--- a/src/webapi/timer_future.rs
+++ b/src/webapi/timer_future.rs
@@ -18,7 +18,8 @@ fn convert_to_i32( ms: u32 ) -> i32 {
 }
 
 
-///
+/// The [`Future`](https://docs.rs/futures/0.2.*/futures/future/trait.Future.html) which is returned by
+/// [`wait`](fn.wait.html).
 // This isn't implemented as a PromiseFuture because Promises do not support cancellation
 #[derive( Debug )]
 pub struct Wait {
@@ -81,7 +82,14 @@ impl Drop for Wait {
     }
 }
 
+/// Creates a [`Future`](https://docs.rs/futures/0.2.*/futures/future/trait.Future.html) which
+/// will return `()` after `ms` milliseconds have passed.
 ///
+/// It might return a long time *after* `ms` milliseconds have passed, but it
+/// will never return *before* `ms` milliseconds have passed.
+///
+/// [(JavaScript docs)](https://developer.mozilla.org/en-US/docs/Web/API/WindowOrWorkerGlobalScope/setTimeout)
+// https://html.spec.whatwg.org/multipage/webappapis.html#dom-settimeout
 #[inline]
 pub fn wait( ms: u32 ) -> Wait {
     Wait::new( ms )
@@ -94,7 +102,8 @@ struct IntervalBufferedState {
     count: usize,
 }
 
-///
+/// The [`Stream`](https://docs.rs/futures/0.2.*/futures/stream/trait.Stream.html)
+/// which is returned by [`interval_buffered`](fn.interval_buffered.html).
 #[derive( Debug )]
 pub struct IntervalBuffered {
     state: Arc< Mutex< IntervalBufferedState > >,
@@ -175,7 +184,21 @@ impl Drop for IntervalBuffered {
     }
 }
 
+/// Creates a [`Stream`](https://docs.rs/futures/0.2.*/futures/stream/trait.Stream.html) which
+/// will continuously output `()` every `ms` milliseconds, until it is dropped.
 ///
+/// It might output `()` a long time *after* `ms` milliseconds have passed, but it
+/// will never output `()` *before* `ms` milliseconds have passed.
+///
+/// If the consumer isn't ready to receive the `()`, it will be put into a queue.
+/// When the consumer is ready, it will output all of the `()` from the queue.
+///
+/// That means that if the consumer is too slow, it might receive multiple `()` at the same time.
+/// Or it might receive another `()` before `ms` milliseconds have passed for the consumer
+/// (that happens because `ms` milliseconds *have* passed for the [`IntervalBuffered`](struct.IntervalBuffered.html)).
+///
+/// [(JavaScript docs)](https://developer.mozilla.org/en-US/docs/Web/API/WindowOrWorkerGlobalScope/setInterval)
+// https://html.spec.whatwg.org/multipage/webappapis.html#dom-setinterval
 #[inline]
 pub fn interval_buffered( ms: u32 ) -> IntervalBuffered {
     IntervalBuffered::new( ms )

--- a/src/webapi/timer_future.rs
+++ b/src/webapi/timer_future.rs
@@ -9,14 +9,14 @@ use futures::unsync::oneshot;
 ///
 // This isn't implemented as a PromiseFuture because Promises do not support cancellation
 #[derive( Debug )]
-pub struct WaitFuture {
+pub struct Wait {
     receiver: oneshot::Receiver< () >,
     callback: Value,
     timer_id: u32,
 }
 
 
-impl WaitFuture {
+impl Wait {
     fn new( ms: u32 ) -> Self {
         // We accept a u32 because we don't want negative values, however setTimeout requires it to be i32
         let ms: i32 = ms as i32;
@@ -49,7 +49,7 @@ impl WaitFuture {
 }
 
 
-impl Future for WaitFuture {
+impl Future for Wait {
     type Item = ();
     // TODO use Void instead
     type Error = Error;
@@ -61,7 +61,7 @@ impl Future for WaitFuture {
 }
 
 
-impl Drop for WaitFuture {
+impl Drop for Wait {
     #[inline]
     fn drop( &mut self ) {
         js! { @(no_return)
@@ -75,7 +75,6 @@ impl Drop for WaitFuture {
 
 ///
 #[inline]
-pub fn wait( ms: u32 ) -> WaitFuture {
-    WaitFuture::new( ms )
+pub fn wait( ms: u32 ) -> Wait {
+    Wait::new( ms )
 }
-

--- a/src/webapi/timer_future.rs
+++ b/src/webapi/timer_future.rs
@@ -1,0 +1,80 @@
+use webcore::once::Once;
+use webcore::try_from::TryInto;
+use webcore::value::Value;
+use webapi::error::Error;
+use futures::{Future, Poll};
+use futures::unsync::oneshot;
+
+
+///
+// This isn't implemented as a PromiseFuture because Promises do not support cancellation
+#[derive( Debug )]
+pub struct TimerFuture {
+	receiver: oneshot::Receiver< () >,
+	callback: Value,
+	timer_id: u32,
+}
+
+
+impl TimerFuture {
+	fn new( ms: u32 ) -> Self {
+		// We accept a u32 because we don't want negative values, however setTimeout requires it to be i32
+		let ms: i32 = ms as i32;
+
+		assert!( ms >= 0, "ms must be less than 2147483648" );
+
+		let ( sender, receiver ) = oneshot::channel();
+
+		let callback = move || {
+			match sender.send( () ) {
+				Ok( _ ) => {},
+				Err( _ ) => {},
+			}
+		};
+
+		let callback = js!( return @{Once( callback )}; );
+
+		let timer_id = js!(
+			return setTimeout( function () {
+				@{&callback}();
+			}, @{ms} );
+		).try_into().unwrap();
+
+		Self {
+			receiver,
+			callback,
+			timer_id,
+		}
+	}
+}
+
+
+impl Future for TimerFuture {
+	type Item = ();
+	// TODO use Void instead
+	type Error = Error;
+
+	#[inline]
+	fn poll( &mut self ) -> Poll< Self::Item, Self::Error > {
+		self.receiver.poll().map_err( |_| unreachable!() )
+	}
+}
+
+
+impl Drop for TimerFuture {
+	#[inline]
+	fn drop( &mut self ) {
+		js! { @(no_return)
+			clearTimeout( @{self.timer_id} );
+			// TODO is it okay to call drop multiple times on the same callback ?
+			@{&self.callback}.drop();
+		}
+	}
+}
+
+
+///
+#[inline]
+pub fn wait( ms: u32 ) -> TimerFuture {
+	TimerFuture::new( ms )
+}

--- a/src/webapi/timer_future.rs
+++ b/src/webapi/timer_future.rs
@@ -9,14 +9,14 @@ use futures::unsync::oneshot;
 ///
 // This isn't implemented as a PromiseFuture because Promises do not support cancellation
 #[derive( Debug )]
-pub struct TimerFuture {
+pub struct WaitFuture {
 	receiver: oneshot::Receiver< () >,
 	callback: Value,
 	timer_id: u32,
 }
 
 
-impl TimerFuture {
+impl WaitFuture {
 	fn new( ms: u32 ) -> Self {
 		// We accept a u32 because we don't want negative values, however setTimeout requires it to be i32
 		let ms: i32 = ms as i32;
@@ -49,7 +49,7 @@ impl TimerFuture {
 }
 
 
-impl Future for TimerFuture {
+impl Future for WaitFuture {
 	type Item = ();
 	// TODO use Void instead
 	type Error = Error;
@@ -61,7 +61,7 @@ impl Future for TimerFuture {
 }
 
 
-impl Drop for TimerFuture {
+impl Drop for WaitFuture {
 	#[inline]
 	fn drop( &mut self ) {
 		js! { @(no_return)
@@ -75,6 +75,7 @@ impl Drop for TimerFuture {
 
 ///
 #[inline]
-pub fn wait( ms: u32 ) -> TimerFuture {
-	TimerFuture::new( ms )
+pub fn wait( ms: u32 ) -> WaitFuture {
+	WaitFuture::new( ms )
 }
+

--- a/src/webapi/timer_future.rs
+++ b/src/webapi/timer_future.rs
@@ -2,8 +2,19 @@ use webcore::once::Once;
 use webcore::try_from::TryInto;
 use webcore::value::Value;
 use webapi::error::Error;
-use futures::{Future, Poll};
+use futures::{Future, Poll, Stream};
 use futures::unsync::oneshot;
+use futures::sync::mpsc;
+
+
+#[inline]
+fn convert_to_i32( ms: u32 ) -> i32 {
+    let ms: i32 = ms as i32;
+
+    assert!( ms >= 0, "ms must be less than 2147483648" );
+
+    ms
+}
 
 
 ///
@@ -15,21 +26,15 @@ pub struct Wait {
     timer_id: u32,
 }
 
-
 impl Wait {
     fn new( ms: u32 ) -> Self {
         // We accept a u32 because we don't want negative values, however setTimeout requires it to be i32
-        let ms: i32 = ms as i32;
-
-        assert!( ms >= 0, "ms must be less than 2147483648" );
+        let ms = convert_to_i32( ms );
 
         let ( sender, receiver ) = oneshot::channel();
 
         let callback = move || {
-            match sender.send( () ) {
-                Ok( _ ) => {},
-                Err( _ ) => {},
-            }
+            sender.send( () ).unwrap();
         };
 
         let callback = js!( return @{Once( callback )}; );
@@ -48,7 +53,6 @@ impl Wait {
     }
 }
 
-
 impl Future for Wait {
     type Item = ();
     // TODO use Void instead
@@ -60,21 +64,81 @@ impl Future for Wait {
     }
 }
 
-
 impl Drop for Wait {
     #[inline]
     fn drop( &mut self ) {
         js! { @(no_return)
             clearTimeout( @{self.timer_id} );
-            // TODO is it okay to call drop multiple times on the same callback ?
             @{&self.callback}.drop();
         }
     }
 }
 
-
 ///
 #[inline]
 pub fn wait( ms: u32 ) -> Wait {
     Wait::new( ms )
+}
+
+
+///
+#[derive( Debug )]
+pub struct IntervalBuffered {
+    receiver: mpsc::UnboundedReceiver< () >,
+    callback: Value,
+    timer_id: u32,
+}
+
+impl IntervalBuffered {
+    fn new( ms: u32 ) -> Self {
+        // We accept a u32 because we don't want negative values, however setInterval requires it to be i32
+        let ms = convert_to_i32( ms );
+
+        let ( sender, receiver ) = mpsc::unbounded();
+
+        let callback = move || {
+            sender.unbounded_send( () ).unwrap();
+        };
+
+        let callback = js!( return @{callback}; );
+
+        let timer_id = js!(
+            return setInterval( function () {
+                @{&callback}();
+            }, @{ms} );
+        ).try_into().unwrap();
+
+        Self {
+            receiver,
+            callback,
+            timer_id,
+        }
+    }
+}
+
+impl Stream for IntervalBuffered {
+    type Item = ();
+    // TODO use Void instead
+    type Error = Error;
+
+    #[inline]
+    fn poll( &mut self ) -> Poll< Option< Self::Item >, Self::Error > {
+        self.receiver.poll().map_err( |_| unreachable!() )
+    }
+}
+
+impl Drop for IntervalBuffered {
+    #[inline]
+    fn drop( &mut self ) {
+        js! { @(no_return)
+            clearInterval( @{self.timer_id} );
+            @{&self.callback}.drop();
+        }
+    }
+}
+
+///
+#[inline]
+pub fn interval_buffered( ms: u32 ) -> IntervalBuffered {
+    IntervalBuffered::new( ms )
 }

--- a/src/webapi/timer_future.rs
+++ b/src/webapi/timer_future.rs
@@ -10,72 +10,72 @@ use futures::unsync::oneshot;
 // This isn't implemented as a PromiseFuture because Promises do not support cancellation
 #[derive( Debug )]
 pub struct WaitFuture {
-	receiver: oneshot::Receiver< () >,
-	callback: Value,
-	timer_id: u32,
+    receiver: oneshot::Receiver< () >,
+    callback: Value,
+    timer_id: u32,
 }
 
 
 impl WaitFuture {
-	fn new( ms: u32 ) -> Self {
-		// We accept a u32 because we don't want negative values, however setTimeout requires it to be i32
-		let ms: i32 = ms as i32;
+    fn new( ms: u32 ) -> Self {
+        // We accept a u32 because we don't want negative values, however setTimeout requires it to be i32
+        let ms: i32 = ms as i32;
 
-		assert!( ms >= 0, "ms must be less than 2147483648" );
+        assert!( ms >= 0, "ms must be less than 2147483648" );
 
-		let ( sender, receiver ) = oneshot::channel();
+        let ( sender, receiver ) = oneshot::channel();
 
-		let callback = move || {
-			match sender.send( () ) {
-				Ok( _ ) => {},
-				Err( _ ) => {},
-			}
-		};
+        let callback = move || {
+            match sender.send( () ) {
+                Ok( _ ) => {},
+                Err( _ ) => {},
+            }
+        };
 
-		let callback = js!( return @{Once( callback )}; );
+        let callback = js!( return @{Once( callback )}; );
 
-		let timer_id = js!(
-			return setTimeout( function () {
-				@{&callback}();
-			}, @{ms} );
-		).try_into().unwrap();
+        let timer_id = js!(
+            return setTimeout( function () {
+                @{&callback}();
+            }, @{ms} );
+        ).try_into().unwrap();
 
-		Self {
-			receiver,
-			callback,
-			timer_id,
-		}
-	}
+        Self {
+            receiver,
+            callback,
+            timer_id,
+        }
+    }
 }
 
 
 impl Future for WaitFuture {
-	type Item = ();
-	// TODO use Void instead
-	type Error = Error;
+    type Item = ();
+    // TODO use Void instead
+    type Error = Error;
 
-	#[inline]
-	fn poll( &mut self ) -> Poll< Self::Item, Self::Error > {
-		self.receiver.poll().map_err( |_| unreachable!() )
-	}
+    #[inline]
+    fn poll( &mut self ) -> Poll< Self::Item, Self::Error > {
+        self.receiver.poll().map_err( |_| unreachable!() )
+    }
 }
 
 
 impl Drop for WaitFuture {
-	#[inline]
-	fn drop( &mut self ) {
-		js! { @(no_return)
-			clearTimeout( @{self.timer_id} );
-			// TODO is it okay to call drop multiple times on the same callback ?
-			@{&self.callback}.drop();
-		}
-	}
+    #[inline]
+    fn drop( &mut self ) {
+        js! { @(no_return)
+            clearTimeout( @{self.timer_id} );
+            // TODO is it okay to call drop multiple times on the same callback ?
+            @{&self.callback}.drop();
+        }
+    }
 }
 
 
 ///
 #[inline]
 pub fn wait( ms: u32 ) -> WaitFuture {
-	WaitFuture::new( ms )
+    WaitFuture::new( ms )
 }
 


### PR DESCRIPTION
@koute @CryZe This is **not** ready to merge yet. It still needs an implementation of `setInterval`, and also documentation.

I want to get feedback on two things:

1. The code for `WaitFuture`. In particular, is it okay to call `.drop()` on a `Once` callback multiple times?

2. I want to implement `setInterval`, however there are actually many different ways to implement it.

   Let's say you use `interval(1000)` to create a `Stream`, it might behave in any of these ways:

   * Every 1 second it sends a `()` message, regardless of whether the consumer is ready or not. These messages will be buffered, and when the consumer is ready it might pull multiple `()` messages at once.

   * Same behavior as above, except it only buffers a single message, so when the consumer is ready it will never pull more than 1 message at once.

   * After the consumer pulls a message, it will wait 1 second before it sends another message. In other words, it's guaranteed that the consumer will not receive a message more than once every 1 second (no matter how fast or slowly it pulls).

   It seems to me that all three of these behaviors are useful (in different situations), so we should probably have three separate functions. What should these functions be called?