### PR TITLE
Adding in default type argument to PromiseFuture

### DIFF
--- a/examples/promise/src/main.rs
+++ b/examples/promise/src/main.rs
@@ -51,10 +51,10 @@ fn test_error_conversion() {
         } )
     );
 
-    let _a: PromiseFuture< Null, Error > = js!( return Promise.resolve( null ); ).try_into().unwrap();
+    let _a: PromiseFuture< Null > = js!( return Promise.resolve( null ); ).try_into().unwrap();
     log( "Null works" );
 
-    let _a: PromiseFuture< Null, Error > = js!( return Promise.reject( new Error( "hi!" ) ); ).try_into().unwrap();
+    let _a: PromiseFuture< Null > = js!( return Promise.reject( new Error( "hi!" ) ); ).try_into().unwrap();
     log( "Error works" );
 
     //let _a: PromiseFuture< Null, SyntaxError > = js!( return Promise.reject( new Error( "hi!" ) ); ).try_into().unwrap();
@@ -233,7 +233,7 @@ fn test_notify() {
 
 
 fn test_timeout() {
-    fn sleep( ms: u32 ) -> PromiseFuture< Null, Error > {
+    fn sleep( ms: u32 ) -> PromiseFuture< Null > {
         js!( return new Promise( function ( success, failure ) {
             setTimeout( function () {
                 success( null );

--- a/src/webcore/promise_future.rs
+++ b/src/webcore/promise_future.rs
@@ -1,6 +1,7 @@
 use std;
 use webcore::value::{Value, ConversionError};
 use webcore::try_from::{TryInto, TryFrom};
+use webapi::error;
 use futures::{Future, Poll, Async};
 use futures::unsync::oneshot::Receiver;
 use webcore::promise_executor::spawn;
@@ -16,13 +17,10 @@ use super::promise::Promise;
 /// Convert a JavaScript `Promise` into a `PromiseFuture`:
 ///
 /// ```rust
-/// use stdweb::PromiseFuture;
-/// use stdweb::web::error::Error;
-///
-/// let future: PromiseFuture<String, Error> = js!( return Promise.resolve("foo"); ).try_into().unwrap();
+/// let future: PromiseFuture<String> = js!( return Promise.resolve("foo"); ).try_into().unwrap();
 /// ```
-pub struct PromiseFuture< A, B > {
-    pub(crate) future: Receiver< Result< A, B > >,
+pub struct PromiseFuture< Value, Error = error::Error > {
+    pub(crate) future: Receiver< Result< Value, Error > >,
 }
 
 impl PromiseFuture< (), () > {


### PR DESCRIPTION
99+% of the time Promises have a JavaScript `Error` object as their error.

In addition, Futures require the error type to be the same when using combinators (such as `and_then`), so it's beneficial to encourage the use of a single `Error` type (the alternative is to constantly cast between error types, which is pretty verbose).

Therefore, I think it makes sense to make the error type of `PromiseFuture` optional (it defaults to `webapi::error::Error`). This solves both of the above problems, while still allowing for error customization in the rare cases where it is needed.