### PR TITLE
Expose WebSocket BinaryType struct

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -326,6 +326,11 @@ pub mod web {
             BlurEvent
         };
     }
+
+    /// A module containing Websocket types.
+    pub mod web_socket {
+        pub use webapi::web_socket::BinaryType;
+    }
 }
 
 /// A module containing stable counterparts to currently

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -225,7 +225,7 @@ pub mod web {
     pub use webapi::typed_array::TypedArray;
     pub use webapi::file_reader::{FileReader, FileReaderResult};
     pub use webapi::history::History;
-    pub use webapi::web_socket::{WebSocket, SocketCloseCode};
+    pub use webapi::web_socket::{WebSocket, SocketCloseCode, SocketBinaryType};
     pub use webapi::rendering_context::{RenderingContext, CanvasRenderingContext2d, CanvasGradient, CanvasPattern, CanvasStyle, ImageData, TextMetrics};
     pub use webapi::mutation_observer::{MutationObserver, MutationObserverHandle, MutationObserverInit, MutationRecord};
     pub use webapi::xml_http_request::{XmlHttpRequest, XhrReadyState};
@@ -325,11 +325,6 @@ pub mod web {
             FocusEvent,
             BlurEvent
         };
-    }
-
-    /// A module containing Websocket types.
-    pub mod web_socket {
-        pub use webapi::web_socket::BinaryType;
     }
 }
 

--- a/src/webapi/web_socket.rs
+++ b/src/webapi/web_socket.rs
@@ -77,7 +77,7 @@ impl IEventTarget for WebSocket {}
 /// [(JavaScript docs)](https://developer.mozilla.org/en-US/docs/Web/API/WebSocket#Attributes)
 // https://html.spec.whatwg.org/#dom-websocket-binarytype
 #[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
-pub enum BinaryType {
+pub enum SocketBinaryType {
     /// A Blob object represents a file-like object of immutable, raw data.
     /// [(Javascript docs)](https://developer.mozilla.org/en-US/docs/Web/API/Blob)
     Blob,
@@ -86,17 +86,17 @@ pub enum BinaryType {
     ArrayBuffer
 }
 
-impl BinaryType {
+impl SocketBinaryType {
     fn to_str(self) -> &'static str {
         match self {
-            BinaryType::Blob => "blob",
-            BinaryType::ArrayBuffer => "arraybuffer",
+            SocketBinaryType::Blob => "blob",
+            SocketBinaryType::ArrayBuffer => "arraybuffer",
         }
     }
     fn from_str(s: &str) -> Self {
         match s {
-            "blob" => BinaryType::Blob,
-            "arraybuffer" => BinaryType::ArrayBuffer,
+            "blob" => SocketBinaryType::Blob,
+            "arraybuffer" => SocketBinaryType::ArrayBuffer,
             other => panic!("Invalid binary type: {:?}", other)
         }
     }
@@ -155,9 +155,9 @@ impl WebSocket {
     ///
     /// [(JavaScript docs)](https://developer.mozilla.org/en-US/docs/Web/API/WebSocket)
     // https://html.spec.whatwg.org/#the-websocket-interface:dom-websocket-binarytype
-    pub fn binary_type(&self) -> BinaryType {
+    pub fn binary_type(&self) -> SocketBinaryType {
         let binary_type: String = js!( return @{self}.binaryType; ).try_into().unwrap();
-        BinaryType::from_str(&binary_type)
+        SocketBinaryType::from_str(&binary_type)
     }
 
     /// Sets the binary type of the web socket. Only affects received messages.
@@ -165,7 +165,7 @@ impl WebSocket {
     ///
     /// [(JavaScript docs)](https://developer.mozilla.org/en-US/docs/Web/API/WebSocket)
     // https://html.spec.whatwg.org/#the-websocket-interface:dom-websocket-binarytype
-    pub fn set_binary_type(&self, binary_type: BinaryType) {
+    pub fn set_binary_type(&self, binary_type: SocketBinaryType) {
         js!( @(no_return) @{self}.binaryType = @{binary_type.to_str()}; );
     }
 

--- a/src/webapi/web_socket.rs
+++ b/src/webapi/web_socket.rs
@@ -72,10 +72,17 @@ pub struct WebSocket( Reference );
 
 impl IEventTarget for WebSocket {}
 
+/// The type of binary data being transmitted by the WebSocket connection.
+///
+/// [(JavaScript docs)](https://developer.mozilla.org/en-US/docs/Web/API/WebSocket#Attributes)
 // https://html.spec.whatwg.org/#dom-websocket-binarytype
 #[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub enum BinaryType {
+    /// A Blob object represents a file-like object of immutable, raw data.
+    /// [(Javascript docs)](https://developer.mozilla.org/en-US/docs/Web/API/Blob)
     Blob,
+    /// The ArrayBuffer object is used to represent a generic, fixed-length raw binary data buffer.
+    /// [(Javascript docs)](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/ArrayBuffer)
     ArrayBuffer
 }
 


### PR DESCRIPTION
As far as I can tell, the `BinaryType` struct needs to be accessible to pass a value into the `WebSocket::set_binary_type` function.