### PR TITLE
missing semicolon lead to invalid javascript after compression

### DIFF
--- a/src/webcore/runtime.js
+++ b/src/webcore/runtime.js
@@ -345,4 +345,4 @@ Module.STDWEB_PRIVATE.unregister_raw_value = function( id ) {
 
 Module.STDWEB_PRIVATE.get_raw_value = function( id ) {
     return Module.STDWEB_PRIVATE.id_to_raw_value_map[ id ];
-}
+};


### PR DESCRIPTION
This line is missing a semicolon. After emcc compile, it becomes:

```javascript
Module.STDWEB_PRIVATE.register_raw_value = function( value ) {     var id = Module.STDWEB_PRIVATE.last_raw_value_id++;     Module.STDWEB_PRIVATE.id_to_raw_value_map[ id ] = value;     return id; };  Module.STDWEB_PRIVATE.unregister_raw_value = function( id ) {     delete Module.STDWEB_PRIVATE.id_to_raw_value_map[ id ]; };  Module.STDWEB_PRIVATE.get_raw_value = function( id ) {     return Module.STDWEB_PRIVATE.id_to_raw_value_map[ id ]; } Module.STDWEB_PRIVATE.alloc = function alloc( size ) {     return _malloc( size ); };  Module.STDWEB_PRIVATE.dyncall = function( signature, ptr, args ) {     return Runtime.dynCall( signature, ptr, args ); };  Module.STDWEB_PRIVATE.utf8_len = function utf8_len( str ) {     return lengthBytesUTF8( str ); };
```
And I got a `Uncaught SyntaxError: Unexpected identifier` in my browser.
