### PR TITLE
Fix memory leak on js! block

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ node_modules
 
 .cache
 examples/hasher-parcel/dist
+*.swp

--- a/src/webcore/runtime.js
+++ b/src/webcore/runtime.js
@@ -300,14 +300,21 @@ Module.STDWEB_PRIVATE.acquire_rust_reference = function( reference ) {
         return 0;
     }
 
-    var refid = Module.STDWEB_PRIVATE.ref_to_id_map.get( reference );
+    var id_to_refcount_map = Module.STDWEB_PRIVATE.id_to_refcount_map;
+    var id_to_ref_map = Module.STDWEB_PRIVATE.id_to_ref_map;
+    var ref_to_id_map = Module.STDWEB_PRIVATE.ref_to_id_map;
+
+    var refid = ref_to_id_map.get( reference );
     if( refid === undefined ) {
         refid = Module.STDWEB_PRIVATE.last_refid++;
-        Module.STDWEB_PRIVATE.ref_to_id_map.set( reference, refid );
-        Module.STDWEB_PRIVATE.id_to_ref_map[ refid ] = reference;
-        Module.STDWEB_PRIVATE.id_to_refcount_map[ refid ] = 1;
+        ref_to_id_map.set( reference, refid );
+    }
+
+    if( refid in id_to_ref_map ) {
+        id_to_refcount_map[ refid ]++;
     } else {
-        Module.STDWEB_PRIVATE.id_to_refcount_map[ refid ]++;
+        id_to_ref_map[ refid ] = reference;
+        id_to_refcount_map[ refid ] = 1;
     }
 
     return refid;
@@ -329,7 +336,6 @@ Module.STDWEB_PRIVATE.decrement_refcount = function( refid ) {
         var reference = id_to_ref_map[ refid ];
         delete id_to_ref_map[ refid ];
         delete id_to_refcount_map[ refid ];
-        Module.STDWEB_PRIVATE.ref_to_id_map.delete( reference );
     }
 };
 

--- a/src/webcore/serialization.rs
+++ b/src/webcore/serialization.rs
@@ -395,7 +395,7 @@ impl SerializedUntaggedSymbol {
 impl SerializedUntaggedReference {
     #[inline]
     fn deserialize( &self ) -> Reference {
-        unsafe { Reference::from_raw_unchecked( self.refid ) }
+        unsafe { Reference::from_raw_unchecked_noref( self.refid ) }
     }
 }
 


### PR DESCRIPTION
Fix https://github.com/koute/stdweb/issues/148

It seems that refcount for JS reference is incremented before serialized to wasm buffer[1], so refcount will be incresed twice if `Reference::from_raw_unchecked` is used on `deserialize`.

[1] https://github.com/koute/stdweb/blob/85f7aa484f3be9808b992b9258bd85fa588e05b1/src/webcore/runtime.js#L303-L311