### PR TITLE
Add document().body(), document().head(), document().title(), document().set_title()

### DIFF
--- a/src/webapi/document.rs
+++ b/src/webapi/document.rs
@@ -2,6 +2,7 @@ use webcore::value::Reference;
 use webapi::event_target::{IEventTarget, EventTarget};
 use webapi::node::{INode, Node};
 use webapi::element::Element;
+use webapi::html_element::HtmlElement;
 use webapi::text_node::TextNode;
 use webapi::location::Location;
 use webapi::parent_node::IParentNode;
@@ -65,6 +66,18 @@ impl Document {
             js!(
                 return @{self}.location;
             ).into_reference_unchecked()
+        }
+    }
+
+    /// Returns the <body> or <frameset> node of the current document, or null if no such element exists.
+    ///
+    /// [(JavaScript docs)](https://developer.mozilla.org/en-US/docs/Web/API/Document/body)
+    // https://html.spec.whatwg.org/#dom-document-body
+    pub fn body( &self ) -> HtmlElement {
+        unsafe {
+            js!(
+                return @{self}.body;
+            ).into_reference_unchecked().unwrap()
         }
     }
 }

--- a/src/webapi/document.rs
+++ b/src/webapi/document.rs
@@ -1,4 +1,5 @@
 use webcore::value::Reference;
+use webcore::try_from::TryInto;
 use webapi::event_target::{IEventTarget, EventTarget};
 use webapi::node::{INode, Node};
 use webapi::element::Element;
@@ -91,6 +92,31 @@ impl Document {
             js!(
                 return @{self}.head;
             ).into_reference_unchecked()
+        }
+    }
+
+    /// Gets the title of the document.
+    ///
+    /// [(JavaScript docs)](https://developer.mozilla.org/en-US/docs/Web/API/Document/title)
+    // https://html.spec.whatwg.org/multipage/semantics.html#the-title-element
+    pub fn get_title( &self ) -> String {
+        unsafe {
+            js!(
+                return @{self}.title;
+            ).try_into().unwrap()
+        }
+    }
+
+    /// Sets the title of the document.
+    ///
+    /// [(JavaScript docs)](https://developer.mozilla.org/en-US/docs/Web/API/Document/title)
+    // https://html.spec.whatwg.org/multipage/semantics.html#the-title-element
+    pub fn set_title( &self, title: &str ) -> String {
+        unsafe {
+            js!(
+                @{self}.title = @{title};
+                return @{self}.title;
+            ).try_into().unwrap()
         }
     }
 }

--- a/src/webapi/document.rs
+++ b/src/webapi/document.rs
@@ -111,12 +111,9 @@ impl Document {
     ///
     /// [(JavaScript docs)](https://developer.mozilla.org/en-US/docs/Web/API/Document/title)
     // https://html.spec.whatwg.org/#the-document-object:document.title
-    pub fn set_title( &self, title: &str ) -> String {
+    pub fn set_title( &self, title: &str ) {
         unsafe {
-            js!(
-                @{self}.title = @{title};
-                return @{self}.title;
-            ).try_into().unwrap()
+            js!( @(no_return) @{self}.title = @{title}; );
         }
     }
 }

--- a/src/webapi/document.rs
+++ b/src/webapi/document.rs
@@ -72,12 +72,12 @@ impl Document {
     /// Returns the <body> or <frameset> node of the current document, or null if no such element exists.
     ///
     /// [(JavaScript docs)](https://developer.mozilla.org/en-US/docs/Web/API/Document/body)
-    // https://html.spec.whatwg.org/#dom-document-body
-    pub fn body( &self ) -> HtmlElement {
+    // https://html.spec.whatwg.org/#the-document-object:dom-document-body
+    pub fn body( &self ) -> Option< HtmlElement > {
         unsafe {
             js!(
                 return @{self}.body;
-            ).into_reference_unchecked().unwrap()
+            ).into_reference_unchecked()
         }
     }
 }

--- a/src/webapi/document.rs
+++ b/src/webapi/document.rs
@@ -80,4 +80,17 @@ impl Document {
             ).into_reference_unchecked()
         }
     }
+
+    /// Returns the <head> element of the current document. If there are more than one <head>
+    /// elements, the first one is returned.
+    ///
+    /// [(JavaScript docs)](https://developer.mozilla.org/en-US/docs/Web/API/Document/head)
+    // https://html.spec.whatwg.org/#the-document-object:dom-document-head
+    pub fn head( &self ) -> Option< HtmlElement > {
+        unsafe {
+            js!(
+                return @{self}.head;
+            ).into_reference_unchecked()
+        }
+    }
 }

--- a/src/webapi/document.rs
+++ b/src/webapi/document.rs
@@ -98,7 +98,7 @@ impl Document {
     /// Gets the title of the document.
     ///
     /// [(JavaScript docs)](https://developer.mozilla.org/en-US/docs/Web/API/Document/title)
-    // https://html.spec.whatwg.org/multipage/semantics.html#the-title-element
+    // https://html.spec.whatwg.org/#the-document-object:document.title
     pub fn get_title( &self ) -> String {
         unsafe {
             js!(
@@ -110,7 +110,7 @@ impl Document {
     /// Sets the title of the document.
     ///
     /// [(JavaScript docs)](https://developer.mozilla.org/en-US/docs/Web/API/Document/title)
-    // https://html.spec.whatwg.org/multipage/semantics.html#the-title-element
+    // https://html.spec.whatwg.org/#the-document-object:document.title
     pub fn set_title( &self, title: &str ) -> String {
         unsafe {
             js!(

--- a/src/webapi/document.rs
+++ b/src/webapi/document.rs
@@ -99,7 +99,7 @@ impl Document {
     ///
     /// [(JavaScript docs)](https://developer.mozilla.org/en-US/docs/Web/API/Document/title)
     // https://html.spec.whatwg.org/#the-document-object:document.title
-    pub fn get_title( &self ) -> String {
+    pub fn title( &self ) -> String {
         unsafe {
             js!(
                 return @{self}.title;


### PR DESCRIPTION
Add `document().body()`

eg: `let body: HtmlElement = document().body();`

Not sure if we want a convenience method for this... I guess you could always use: `query_selector("body")`

