### PR TITLE
Add scroll_top()

### DIFF
--- a/src/webapi/document.rs
+++ b/src/webapi/document.rs
@@ -116,4 +116,13 @@ impl Document {
             js!( @(no_return) @{self}.title = @{title}; );
         }
     }
+
+    /// documentElement
+    pub fn document_element( &self ) -> Option< HtmlElement > {
+        unsafe {
+            js!(
+                return @{self}.documentElement;
+            ).try_into().unwrap()
+        }
+    }
 }

--- a/src/webapi/document.rs
+++ b/src/webapi/document.rs
@@ -117,7 +117,11 @@ impl Document {
         }
     }
 
-    /// documentElement
+    /// Returns the Element that is the root element of the document (for example, the <html>
+    /// element for HTML documents).
+    ///
+    /// [(JavaScript docs)](https://developer.mozilla.org/en-US/docs/Web/API/Document/documentElement)
+    // https://www.w3.org/TR/DOM-Level-2-Core/core.html#ID-87CD092
     pub fn document_element( &self ) -> Option< HtmlElement > {
         unsafe {
             js!(

--- a/src/webapi/document.rs
+++ b/src/webapi/document.rs
@@ -70,7 +70,7 @@ impl Document {
         }
     }
 
-    /// Returns the <body> or <frameset> node of the current document, or null if no such element exists.
+    /// Returns the `<body>` or `<frameset>` node of the current document, or null if no such element exists.
     ///
     /// [(JavaScript docs)](https://developer.mozilla.org/en-US/docs/Web/API/Document/body)
     // https://html.spec.whatwg.org/#the-document-object:dom-document-body
@@ -82,7 +82,7 @@ impl Document {
         }
     }
 
-    /// Returns the <head> element of the current document. If there are more than one <head>
+    /// Returns the `<head>` element of the current document. If there are more than one `<head>`
     /// elements, the first one is returned.
     ///
     /// [(JavaScript docs)](https://developer.mozilla.org/en-US/docs/Web/API/Document/head)
@@ -117,12 +117,12 @@ impl Document {
         }
     }
 
-    /// Returns the Element that is the root element of the document (for example, the <html>
+    /// Returns the Element that is the root element of the document (for example, the `<html>`
     /// element for HTML documents).
     ///
     /// [(JavaScript docs)](https://developer.mozilla.org/en-US/docs/Web/API/Document/documentElement)
-    // https://www.w3.org/TR/DOM-Level-2-Core/core.html#ID-87CD092
-    pub fn document_element( &self ) -> Option< HtmlElement > {
+    // https://dom.spec.whatwg.org/#ref-for-dom-document-documentelement
+    pub fn document_element( &self ) -> Option< Element > {
         unsafe {
             js!(
                 return @{self}.documentElement;

--- a/src/webapi/element.rs
+++ b/src/webapi/element.rs
@@ -60,28 +60,40 @@ pub trait IElement: INode + IParentNode {
         ).unwrap()
     }
 
-    /// scrollTop
+    /// Gets the the number of pixels that an element's content is scrolled vertically.
+    ///
+    /// [(Javascript docs)](https://developer.mozilla.org/en-US/docs/Web/API/Element/scrollTop)
+    // https://www.w3.org/TR/cssom-view-1/#dom-element-scrolltop
     fn scroll_top( &self ) -> f64 {
         js!(
             return @{self.as_ref()}.scrollTop;
         ).try_into().unwrap()
     }
 
-    /// scrollTop
+    /// Sets the the number of pixels that an element's content is scrolled vertically.
+    ///
+    /// [(Javascript docs)](https://developer.mozilla.org/en-US/docs/Web/API/Element/scrollTop)
+    // https://www.w3.org/TR/cssom-view-1/#dom-element-scrolltop
     fn set_scroll_top( &self, value: f64 ) {
         js! { @(no_return)
             @{self.as_ref()}.scrollTop = @{value};
         }
     }
 
-    /// scrollLeft
+    /// Gets the the number of pixels that an element's content is scrolled to the left.
+    ///
+    /// [(Javascript docs)](https://developer.mozilla.org/en-US/docs/Web/API/Element/scrollLeft)
+    // https://www.w3.org/TR/cssom-view-1/#dom-element-scrollleft
     fn scroll_left( &self ) -> f64 {
         js!(
             return @{self.as_ref()}.scrollLeft;
         ).try_into().unwrap()
     }
 
-    /// scrollLeft
+    /// Sets the the number of pixels that an element's content is scrolled to the left.
+    ///
+    /// [(Javascript docs)](https://developer.mozilla.org/en-US/docs/Web/API/Element/scrollLeft)
+    // https://www.w3.org/TR/cssom-view-1/#dom-element-scrollleft
     fn set_scroll_left( &self, value: f64 ) {
         js! { @(no_return)
             @{self.as_ref()}.scrollLeft = @{value};

--- a/src/webapi/element.rs
+++ b/src/webapi/element.rs
@@ -60,6 +60,20 @@ pub trait IElement: INode + IParentNode {
         ).unwrap()
     }
 
+    /// scrollTop
+    fn scroll_top( &self ) -> i32 {
+        js!(
+            return @{self.as_ref()}.scrollTop;
+        ).try_into().unwrap()
+    }
+
+    /// scrollTop
+    fn set_scroll_top( &self, value: u32 ) {
+        js! { @(no_return)
+            @{self.as_ref()}.scrollTop = @{value};
+        }
+    }
+
     /// Element.getAttributeNames() returns the attribute names of the element
     /// as an Array of strings. If the element has no attributes it returns an empty array.
     ///

--- a/src/webapi/element.rs
+++ b/src/webapi/element.rs
@@ -63,7 +63,7 @@ pub trait IElement: INode + IParentNode {
     /// Gets the the number of pixels that an element's content is scrolled vertically.
     ///
     /// [(Javascript docs)](https://developer.mozilla.org/en-US/docs/Web/API/Element/scrollTop)
-    // https://drafts.csswg.org/cssom-view/#dom-element-scrolltop
+    // https://drafts.csswg.org/cssom-view/#ref-for-dom-element-scrolltop%E2%91%A0
     fn scroll_top( &self ) -> f64 {
         js!(
             return @{self.as_ref()}.scrollTop;
@@ -73,7 +73,7 @@ pub trait IElement: INode + IParentNode {
     /// Sets the the number of pixels that an element's content is scrolled vertically.
     ///
     /// [(Javascript docs)](https://developer.mozilla.org/en-US/docs/Web/API/Element/scrollTop)
-    // https://drafts.csswg.org/cssom-view/#dom-element-scrolltop
+    // https://drafts.csswg.org/cssom-view/#ref-for-dom-element-scrolltop%E2%91%A0
     fn set_scroll_top( &self, value: f64 ) {
         js! { @(no_return)
             @{self.as_ref()}.scrollTop = @{value};
@@ -83,7 +83,7 @@ pub trait IElement: INode + IParentNode {
     /// Gets the the number of pixels that an element's content is scrolled to the left.
     ///
     /// [(Javascript docs)](https://developer.mozilla.org/en-US/docs/Web/API/Element/scrollLeft)
-    // https://drafts.csswg.org/cssom-view/#dom-element-scrollleft
+    // https://drafts.csswg.org/cssom-view/#ref-for-dom-element-scrollleft%E2%91%A0
     fn scroll_left( &self ) -> f64 {
         js!(
             return @{self.as_ref()}.scrollLeft;
@@ -93,7 +93,7 @@ pub trait IElement: INode + IParentNode {
     /// Sets the the number of pixels that an element's content is scrolled to the left.
     ///
     /// [(Javascript docs)](https://developer.mozilla.org/en-US/docs/Web/API/Element/scrollLeft)
-    // https://drafts.csswg.org/cssom-view/#dom-element-scrollleft
+    // https://drafts.csswg.org/cssom-view/#ref-for-dom-element-scrollleft%E2%91%A0
     fn set_scroll_left( &self, value: f64 ) {
         js! { @(no_return)
             @{self.as_ref()}.scrollLeft = @{value};

--- a/src/webapi/element.rs
+++ b/src/webapi/element.rs
@@ -63,7 +63,7 @@ pub trait IElement: INode + IParentNode {
     /// Gets the the number of pixels that an element's content is scrolled vertically.
     ///
     /// [(Javascript docs)](https://developer.mozilla.org/en-US/docs/Web/API/Element/scrollTop)
-    // https://www.w3.org/TR/cssom-view-1/#dom-element-scrolltop
+    // https://drafts.csswg.org/cssom-view/#dom-element-scrolltop
     fn scroll_top( &self ) -> f64 {
         js!(
             return @{self.as_ref()}.scrollTop;
@@ -73,7 +73,7 @@ pub trait IElement: INode + IParentNode {
     /// Sets the the number of pixels that an element's content is scrolled vertically.
     ///
     /// [(Javascript docs)](https://developer.mozilla.org/en-US/docs/Web/API/Element/scrollTop)
-    // https://www.w3.org/TR/cssom-view-1/#dom-element-scrolltop
+    // https://drafts.csswg.org/cssom-view/#dom-element-scrolltop
     fn set_scroll_top( &self, value: f64 ) {
         js! { @(no_return)
             @{self.as_ref()}.scrollTop = @{value};
@@ -83,7 +83,7 @@ pub trait IElement: INode + IParentNode {
     /// Gets the the number of pixels that an element's content is scrolled to the left.
     ///
     /// [(Javascript docs)](https://developer.mozilla.org/en-US/docs/Web/API/Element/scrollLeft)
-    // https://www.w3.org/TR/cssom-view-1/#dom-element-scrollleft
+    // https://drafts.csswg.org/cssom-view/#dom-element-scrollleft
     fn scroll_left( &self ) -> f64 {
         js!(
             return @{self.as_ref()}.scrollLeft;
@@ -93,7 +93,7 @@ pub trait IElement: INode + IParentNode {
     /// Sets the the number of pixels that an element's content is scrolled to the left.
     ///
     /// [(Javascript docs)](https://developer.mozilla.org/en-US/docs/Web/API/Element/scrollLeft)
-    // https://www.w3.org/TR/cssom-view-1/#dom-element-scrollleft
+    // https://drafts.csswg.org/cssom-view/#dom-element-scrollleft
     fn set_scroll_left( &self, value: f64 ) {
         js! { @(no_return)
             @{self.as_ref()}.scrollLeft = @{value};

--- a/src/webapi/element.rs
+++ b/src/webapi/element.rs
@@ -74,6 +74,20 @@ pub trait IElement: INode + IParentNode {
         }
     }
 
+    /// scrollLeft
+    fn scroll_left( &self ) -> f64 {
+        js!(
+            return @{self.as_ref()}.scrollLeft;
+        ).try_into().unwrap()
+    }
+
+    /// scrollLeft
+    fn set_scroll_left( &self, value: f64 ) {
+        js! { @(no_return)
+            @{self.as_ref()}.scrollLeft = @{value};
+        }
+    }
+
     /// Element.getAttributeNames() returns the attribute names of the element
     /// as an Array of strings. If the element has no attributes it returns an empty array.
     ///

--- a/src/webapi/element.rs
+++ b/src/webapi/element.rs
@@ -61,14 +61,14 @@ pub trait IElement: INode + IParentNode {
     }
 
     /// scrollTop
-    fn scroll_top( &self ) -> i32 {
+    fn scroll_top( &self ) -> f64 {
         js!(
             return @{self.as_ref()}.scrollTop;
         ).try_into().unwrap()
     }
 
     /// scrollTop
-    fn set_scroll_top( &self, value: u32 ) {
+    fn set_scroll_top( &self, value: f64 ) {
         js! { @(no_return)
             @{self.as_ref()}.scrollTop = @{value};
         }

--- a/src/webapi/window.rs
+++ b/src/webapi/window.rs
@@ -192,7 +192,7 @@ impl Window {
     }
 
     /// pageYOffset
-    pub fn page_y_offset(&self) -> i32 {
+    pub fn page_y_offset(&self) -> f64 {
         js!(
             return @{self}.pageYOffset;
         ).try_into().unwrap()

--- a/src/webapi/window.rs
+++ b/src/webapi/window.rs
@@ -191,14 +191,23 @@ impl Window {
         ).try_into().unwrap()
     }
 
-    /// pageYOffset
+    /// he read-only Window property pageYOffset is an alias for scrollY; as such, it returns
+    /// the number of pixels the document is currently scrolled along the vertical axis (that is,
+    /// up or down), with a value of 0.0 indicating that the top edge of the Document is currently
+    /// aligned with the top edge of the window's content area.
+    ///
+    /// [(JavaScript docs)](https://developer.mozilla.org/en-US/docs/Web/API/Window/pageYOffset)
+    // https://drafts.csswg.org/cssom-view/#dom-window-pageyoffset
     pub fn page_y_offset(&self) -> f64 {
         js!(
             return @{self}.pageYOffset;
         ).try_into().unwrap()
     }
 
-    /// pageXOffset
+    /// This is an alias for scrollX.
+    ///
+    /// [(JavaScript docs)](https://developer.mozilla.org/en-US/docs/Web/API/Window/pageXOffset)
+    // https://drafts.csswg.org/cssom-view/#dom-window-pagexoffset
     pub fn page_x_offset(&self) -> f64 {
         js!(
             return @{self}.pageXOffset;

--- a/src/webapi/window.rs
+++ b/src/webapi/window.rs
@@ -190,4 +190,11 @@ impl Window {
             return @{self}.outerHeight;
         ).try_into().unwrap()
     }
+
+    /// pageYOffset
+    pub fn page_y_offset(&self) -> i32 {
+        js!(
+            return @{self}.pageYOffset;
+        ).try_into().unwrap()
+    }
 }

--- a/src/webapi/window.rs
+++ b/src/webapi/window.rs
@@ -197,7 +197,7 @@ impl Window {
     /// aligned with the top edge of the window's content area.
     ///
     /// [(JavaScript docs)](https://developer.mozilla.org/en-US/docs/Web/API/Window/pageYOffset)
-    // https://drafts.csswg.org/cssom-view/#dom-window-pageyoffset
+    // https://drafts.csswg.org/cssom-view/#ref-for-dom-window-pageyoffset
     pub fn page_y_offset(&self) -> f64 {
         js!(
             return @{self}.pageYOffset;
@@ -207,7 +207,7 @@ impl Window {
     /// This is an alias for scrollX.
     ///
     /// [(JavaScript docs)](https://developer.mozilla.org/en-US/docs/Web/API/Window/pageXOffset)
-    // https://drafts.csswg.org/cssom-view/#dom-window-pagexoffset
+    // https://drafts.csswg.org/cssom-view/#ref-for-dom-window-pagexoffset
     pub fn page_x_offset(&self) -> f64 {
         js!(
             return @{self}.pageXOffset;

--- a/src/webapi/window.rs
+++ b/src/webapi/window.rs
@@ -197,4 +197,11 @@ impl Window {
             return @{self}.pageYOffset;
         ).try_into().unwrap()
     }
+
+    /// pageXOffset
+    pub fn page_x_offset(&self) -> f64 {
+        js!(
+            return @{self}.pageXOffset;
+        ).try_into().unwrap()
+    }
 }


### PR DESCRIPTION
Just floating this for some early feedback, still need to add docs, but thought I'd open a PR...

example usage (which I am doing for my own website: <a href='ricky.codes'>ricky.codes</a>):

```rust
let top = Some(window().page_y_offset()).unwrap_or(document().document_element().unwrap().scroll_top());
```

and then setting:
```rust
document().document_element().unwrap().set_scroll_top(top.parse::<u32>().unwrap());
```