### PR TITLE
Implement fallback for references which cannot be stored in a WeakMap

### DIFF
--- a/src/webcore/discard.rs
+++ b/src/webcore/discard.rs
@@ -99,6 +99,7 @@ mod tests {
     }
 
     #[test]
+    #[allow(unused_must_use)]
     fn unused_discard_on_drop() {
         DiscardOnDrop::new( Foo::new() );
     }

--- a/src/webcore/serialization.rs
+++ b/src/webcore/serialization.rs
@@ -1290,6 +1290,25 @@ mod test_deserialization {
     }
 
     #[test]
+    fn bad_reference() {
+        assert_eq!( js! {
+            var WeakMapProto = WeakMap.prototype;
+            if (WeakMapProto.BAD_REFERENCE === undefined) {
+                WeakMapProto.BAD_REFERENCE = {};
+                WeakMapProto.oldSet = WeakMapProto.set;
+                WeakMapProto.set = function(key, value) {
+                    if (key === WeakMapProto.BAD_REFERENCE) {
+                        throw new TypeError("BAD_REFERENCE");
+                    } else {
+                        return this.oldSet(key, value);
+                    }
+                };
+            }
+            return WeakMapProto.BAD_REFERENCE;
+        }.is_reference(), true );
+    }
+
+    #[test]
     fn arguments() {
         let value = js! {
             return (function() {


### PR DESCRIPTION
Fixes #92 

This implements a fallback mechanism using a normal `Map` if attempting to store an object in the `WeakMap` throws an exception - objects stored here are explicitly removed when their reference count reaches zero, meaning that there are no leaks, but that the "stable ID" guarantee does not hold for these specific objects.

This likely comes with a performance penalty due to the use of exception handling.

Personally I would prefer the "stable ID" guarantee to be dropped entirely from `webcore`, and instead a `WeakMap` type was exposed so that stable IDs could still be achieved by opting in for specific objects.