### PR TITLE
Added reference attribute constraint parameter to address #162

### DIFF
--- a/src/webapi/events/dom.rs
+++ b/src/webapi/events/dom.rs
@@ -9,7 +9,7 @@ use webapi::event::{IEvent, IUiEvent, UiEvent, Event, ConcreteEvent};
 /// [(JavaScript docs)](https://developer.mozilla.org/en-US/docs/Web/Events/change)
 // https://html.spec.whatwg.org/#event-change
 #[derive(Clone, Debug, PartialEq, Eq, ReferenceType)]
-#[reference(instance_of = "Event")] // TODO: Better type check.
+#[reference(instance_of = "Event", constraint="type=change")]
 #[reference(subclass_of(Event))]
 pub struct ChangeEvent( Reference );
 
@@ -29,7 +29,7 @@ impl ConcreteEvent for ChangeEvent {
 /// [(JavaScript docs)](https://developer.mozilla.org/en-US/docs/Web/Events/input)
 // https://html.spec.whatwg.org/#event-input
 #[derive(Clone, Debug, PartialEq, Eq, ReferenceType)]
-#[reference(instance_of = "Event")] // TODO: Better type check.
+#[reference(instance_of = "Event", constraint="type=input")]
 #[reference(subclass_of(Event))]
 pub struct InputEvent( Reference );
 
@@ -43,7 +43,7 @@ impl ConcreteEvent for InputEvent {
 /// [(JavaScript docs)](https://developer.mozilla.org/en-US/docs/Web/Events/load)
 // https://w3c.github.io/uievents/#load
 #[derive(Clone, Debug, PartialEq, Eq, ReferenceType)]
-#[reference(instance_of = "UIEvent")] // TODO: Better type check.
+#[reference(instance_of = "UIEvent", constraint="type=load")]
 #[reference(subclass_of(Event, UiEvent))]
 pub struct ResourceLoadEvent( Reference );
 
@@ -58,7 +58,7 @@ impl ConcreteEvent for ResourceLoadEvent {
 /// [(JavaScript docs)](https://developer.mozilla.org/en-US/docs/Web/Events/abort)
 // https://w3c.github.io/uievents/#event-type-abort
 #[derive(Clone, Debug, PartialEq, Eq, ReferenceType)]
-#[reference(instance_of = "UIEvent")] // TODO: Better type check.
+#[reference(instance_of = "UIEvent", constraint="type=abort")]
 #[reference(subclass_of(Event, UiEvent))]
 pub struct ResourceAbortEvent( Reference );
 
@@ -74,7 +74,7 @@ impl ConcreteEvent for ResourceAbortEvent {
 /// [(JavaScript docs)](https://developer.mozilla.org/en-US/docs/Web/Events/error)
 // https://w3c.github.io/uievents/#event-type-error
 #[derive(Clone, Debug, PartialEq, Eq, ReferenceType)]
-#[reference(instance_of = "UIEvent")] // TODO: Better type check.
+#[reference(instance_of = "UIEvent", constraint="type=error")]
 #[reference(subclass_of(Event, UiEvent))]
 pub struct ResourceErrorEvent( Reference );
 
@@ -91,7 +91,7 @@ impl ConcreteEvent for ResourceErrorEvent {
 /// [(JavaScript docs)](https://developer.mozilla.org/en-US/docs/Web/Events/resize)
 // https://drafts.csswg.org/cssom-view/#eventdef-window-resize
 #[derive(Clone, Debug, PartialEq, Eq, ReferenceType)]
-#[reference(instance_of = "Event")] // TODO: Better type check.
+#[reference(instance_of = "Event", constraint="type=resize")]
 #[reference(subclass_of(Event))]
 pub struct ResizeEvent( Reference );
 
@@ -105,7 +105,7 @@ impl ConcreteEvent for ResizeEvent {
 /// [(JavaScript docs)](https://developer.mozilla.org/en-US/docs/Web/Events/readystatechange)
 // https://html.spec.whatwg.org/#event-readystatechange
 #[derive(Clone, Debug, PartialEq, Eq, ReferenceType)]
-#[reference(instance_of = "Event")] // TODO: Better type check.
+#[reference(instance_of = "Event", constraint="type=readystatechange")]
 #[reference(subclass_of(Event))]
 pub struct ReadyStateChangeEvent( Reference );
 

--- a/src/webapi/events/focus.rs
+++ b/src/webapi/events/focus.rs
@@ -40,7 +40,7 @@ impl IFocusEvent for FocusRelatedEvent {}
 /// [(JavaScript docs)](https://developer.mozilla.org/en-US/docs/Web/Events/focus)
 // https://w3c.github.io/uievents/#event-type-focus
 #[derive(Clone, Debug, PartialEq, Eq, ReferenceType)]
-#[reference(instance_of = "FocusEvent")] // TODO: Better type check.
+#[reference(instance_of = "FocusEvent", constraint="type=focus")]
 #[reference(subclass_of(Event, FocusRelatedEvent))]
 pub struct FocusEvent( Reference );
 
@@ -56,7 +56,7 @@ impl ConcreteEvent for FocusEvent {
 /// [(JavaScript docs)](https://developer.mozilla.org/en-US/docs/Web/Events/blur)
 // https://w3c.github.io/uievents/#event-type-blur
 #[derive(Clone, Debug, PartialEq, Eq, ReferenceType)]
-#[reference(instance_of = "FocusEvent")] // TODO: Better type check.
+#[reference(instance_of = "FocusEvent", constraint="type=blur")]
 #[reference(subclass_of(Event, FocusRelatedEvent))]
 pub struct BlurEvent( Reference );
 

--- a/src/webapi/events/history.rs
+++ b/src/webapi/events/history.rs
@@ -52,7 +52,7 @@ impl HashChangeEvent {
 // https://html.spec.whatwg.org/#event-popstate
 // https://html.spec.whatwg.org/#popstateevent
 #[derive(Clone, Debug, PartialEq, Eq, ReferenceType)]
-#[reference(instance_of = "Event")] // TODO: Better type check.
+#[reference(instance_of = "Event", constraint="type=popstate")]
 #[reference(subclass_of(Event))]
 pub struct PopStateEvent(Reference);
 

--- a/src/webapi/events/keyboard.rs
+++ b/src/webapi/events/keyboard.rs
@@ -208,7 +208,7 @@ impl IKeyboardEvent for KeyboardEvent {}
 /// [(JavaScript docs)](https://developer.mozilla.org/en-US/docs/Web/Events/keypress)
 // https://w3c.github.io/uievents/#keypress
 #[derive(Clone, Debug, PartialEq, Eq, ReferenceType)]
-#[reference(instance_of = "KeyboardEvent")] // TODO: Better type check.
+#[reference(instance_of = "KeyboardEvent", constraint="type=keypress")]
 #[reference(subclass_of(Event, KeyboardEvent))]
 pub struct KeyPressEvent( Reference );
 
@@ -225,7 +225,7 @@ impl ConcreteEvent for KeyPressEvent {
 /// [(JavaScript docs)](https://developer.mozilla.org/en-US/docs/Web/Events/keydown)
 // https://w3c.github.io/uievents/#event-type-keydown
 #[derive(Clone, Debug, PartialEq, Eq, ReferenceType)]
-#[reference(instance_of = "KeyboardEvent")] // TODO: Better type check.
+#[reference(instance_of = "KeyboardEvent", constraint="type=keydown")]
 #[reference(subclass_of(Event, KeyboardEvent))]
 pub struct KeyDownEvent( Reference );
 
@@ -240,7 +240,7 @@ impl ConcreteEvent for KeyDownEvent {
 /// [(JavaScript docs)](https://developer.mozilla.org/en-US/docs/Web/Events/keyup)
 // https://w3c.github.io/uievents/#event-type-keyup
 #[derive(Clone, Debug, PartialEq, Eq, ReferenceType)]
-#[reference(instance_of = "KeyboardEvent")] // TODO: Better type check.
+#[reference(instance_of = "KeyboardEvent", constraint="type=keyup")]
 #[reference(subclass_of(Event, KeyboardEvent))]
 pub struct KeyUpEvent( Reference );
 

--- a/src/webapi/events/mouse.rs
+++ b/src/webapi/events/mouse.rs
@@ -235,7 +235,7 @@ impl IMouseEvent for MouseEvent {}
 /// [(JavaScript docs)](https://developer.mozilla.org/en-US/docs/Web/Events/click)
 // https://w3c.github.io/uievents/#event-type-click
 #[derive(Clone, Debug, PartialEq, Eq, ReferenceType)]
-#[reference(instance_of = "MouseEvent")] // TODO: Better type check.
+#[reference(instance_of = "MouseEvent", constraint="type=click")]
 #[reference(subclass_of(Event, UiEvent, MouseEvent))]
 pub struct ClickEvent( Reference );
 
@@ -253,7 +253,7 @@ impl ConcreteEvent for ClickEvent {
 /// [(JavaScript docs)](https://developer.mozilla.org/en-US/docs/Web/Events/dblclick)
 // https://w3c.github.io/uievents/#event-type-dblclick
 #[derive(Clone, Debug, PartialEq, Eq, ReferenceType)]
-#[reference(instance_of = "MouseEvent")] // TODO: Better type check.
+#[reference(instance_of = "MouseEvent", constraint="type=dblclick")]
 #[reference(subclass_of(Event, UiEvent, MouseEvent))]
 pub struct DoubleClickEvent( Reference );
 
@@ -270,7 +270,7 @@ impl ConcreteEvent for DoubleClickEvent {
 /// [(JavaScript docs)](https://developer.mozilla.org/en-US/docs/Web/Events/mousedown)
 // https://w3c.github.io/uievents/#event-type-mousedown
 #[derive(Clone, Debug, PartialEq, Eq, ReferenceType)]
-#[reference(instance_of = "MouseEvent")] // TODO: Better type check.
+#[reference(instance_of = "MouseEvent", constraint="type=mousedown")]
 #[reference(subclass_of(Event, UiEvent, MouseEvent))]
 pub struct MouseDownEvent( Reference );
 
@@ -287,7 +287,7 @@ impl ConcreteEvent for MouseDownEvent {
 /// [(JavaScript docs)](https://developer.mozilla.org/en-US/docs/Web/Events/mouseup)
 // https://w3c.github.io/uievents/#event-type-mouseup
 #[derive(Clone, Debug, PartialEq, Eq, ReferenceType)]
-#[reference(instance_of = "MouseEvent")] // TODO: Better type check.
+#[reference(instance_of="MouseEvent", constraint="type=mouseup")]
 #[reference(subclass_of(Event, UiEvent, MouseEvent))]
 pub struct MouseUpEvent( Reference );
 
@@ -304,7 +304,7 @@ impl ConcreteEvent for MouseUpEvent {
 /// [(JavaScript docs)](https://developer.mozilla.org/en-US/docs/Web/Events/mousemove)
 // https://w3c.github.io/uievents/#event-type-mousemove
 #[derive(Clone, Debug, PartialEq, Eq, ReferenceType)]
-#[reference(instance_of = "MouseEvent")] // TODO: Better type check.
+#[reference(instance_of = "MouseEvent", constraint="type=mousemove")]
 #[reference(subclass_of(Event, UiEvent, MouseEvent))]
 pub struct MouseMoveEvent( Reference );
 
@@ -321,7 +321,7 @@ impl ConcreteEvent for MouseMoveEvent {
 /// [(JavaScript docs)](https://developer.mozilla.org/en-US/docs/Web/Events/mouseover)
 // https://w3c.github.io/uievents/#event-type-mouseover
 #[derive(Clone, Debug, PartialEq, Eq, ReferenceType)]
-#[reference(instance_of = "MouseEvent")] // TODO: Better type check.
+#[reference(instance_of = "MouseEvent", constraint="type=mouseover")]
 #[reference(subclass_of(Event, UiEvent, MouseEvent))]
 pub struct MouseOverEvent( Reference );
 
@@ -338,7 +338,7 @@ impl ConcreteEvent for MouseOverEvent {
 /// [(JavaScript docs)](https://developer.mozilla.org/en-US/docs/Web/Events/mouseout)
 // https://w3c.github.io/uievents/#event-type-mouseout
 #[derive(Clone, Debug, PartialEq, Eq, ReferenceType)]
-#[reference(instance_of = "MouseEvent")] // TODO: Better type check.
+#[reference(instance_of = "MouseEvent", constraint="type=mouseout")]
 #[reference(subclass_of(Event, UiEvent, MouseEvent))]
 pub struct MouseOutEvent( Reference );
 

--- a/src/webapi/events/pointer.rs
+++ b/src/webapi/events/pointer.rs
@@ -173,7 +173,7 @@ impl IPointerEvent for PointerEvent {}
 /// [(JavaScript docs)](https://developer.mozilla.org/en-US/docs/Web/Events/pointerover)
 // https://w3c.github.io/pointerevents/#the-pointerover-event
 #[derive(Clone, Debug, PartialEq, Eq, ReferenceType)]
-#[reference(instance_of = "PointerEvent")] // TODO: Better type check.
+#[reference(instance_of = "PointerEvent", constraint="type=pointerover")]
 #[reference(subclass_of(Event, UiEvent, MouseEvent, PointerEvent))]
 pub struct PointerOverEvent( Reference );
 
@@ -191,7 +191,7 @@ impl ConcreteEvent for PointerOverEvent {
 /// [(JavaScript docs)](https://developer.mozilla.org/en-US/docs/Web/Events/pointerenter)
 // https://w3c.github.io/pointerevents/#the-pointerenter-event
 #[derive(Clone, Debug, PartialEq, Eq, ReferenceType)]
-#[reference(instance_of = "PointerEvent")] // TODO: Better type check.
+#[reference(instance_of = "PointerEvent", constraint="type=pointerenter")]
 #[reference(subclass_of(Event, UiEvent, MouseEvent, PointerEvent))]
 pub struct PointerEnterEvent( Reference );
 
@@ -208,7 +208,7 @@ impl ConcreteEvent for PointerEnterEvent {
 /// [(JavaScript docs)](https://developer.mozilla.org/en-US/docs/Web/Events/pointerdown)
 // https://w3c.github.io/pointerevents/#the-pointerdown-event
 #[derive(Clone, Debug, PartialEq, Eq, ReferenceType)]
-#[reference(instance_of = "PointerEvent")] // TODO: Better type check.
+#[reference(instance_of = "PointerEvent", constraint="type=pointerdown")]
 #[reference(subclass_of(Event, UiEvent, MouseEvent, PointerEvent))]
 pub struct PointerDownEvent( Reference );
 
@@ -225,7 +225,7 @@ impl ConcreteEvent for PointerDownEvent {
 /// [(JavaScript docs)](https://developer.mozilla.org/en-US/docs/Web/Events/pointermove)
 // https://w3c.github.io/pointerevents/#the-pointermove-event
 #[derive(Clone, Debug, PartialEq, Eq, ReferenceType)]
-#[reference(instance_of = "PointerEvent")] // TODO: Better type check.
+#[reference(instance_of = "PointerEvent", constraint="type=pointermove")]
 #[reference(subclass_of(Event, UiEvent, MouseEvent, PointerEvent))]
 pub struct PointerMoveEvent( Reference );
 
@@ -256,7 +256,7 @@ impl PointerMoveEvent
 /// [(JavaScript docs)](https://developer.mozilla.org/en-US/docs/Web/Events/pointerup)
 // https://w3c.github.io/pointerevents/#the-pointerup-event
 #[derive(Clone, Debug, PartialEq, Eq, ReferenceType)]
-#[reference(instance_of = "PointerEvent")] // TODO: Better type check.
+#[reference(instance_of = "PointerEvent", constraint="type=pointerup")]
 #[reference(subclass_of(Event, UiEvent, MouseEvent, PointerEvent))]
 pub struct PointerUpEvent( Reference );
 
@@ -275,7 +275,7 @@ impl ConcreteEvent for PointerUpEvent {
 /// [(JavaScript docs)](https://developer.mozilla.org/en-US/docs/Web/Events/pointercancel)
 // https://w3c.github.io/pointerevents/#the-pointercancel-event
 #[derive(Clone, Debug, PartialEq, Eq, ReferenceType)]
-#[reference(instance_of = "PointerEvent")] // TODO: Better type check.
+#[reference(instance_of = "PointerEvent", constraint="type=pointercancel")]
 #[reference(subclass_of(Event, UiEvent, MouseEvent, PointerEvent))]
 pub struct PointerCancelEvent( Reference );
 
@@ -293,7 +293,7 @@ impl ConcreteEvent for PointerCancelEvent {
 /// [(JavaScript docs)](https://developer.mozilla.org/en-US/docs/Web/Events/pointerout)
 // https://w3c.github.io/pointerevents/#the-pointerout-event
 #[derive(Clone, Debug, PartialEq, Eq, ReferenceType)]
-#[reference(instance_of = "PointerEvent")] // TODO: Better type check.
+#[reference(instance_of = "PointerEvent", constraint="type=pointerout")]
 #[reference(subclass_of(Event, UiEvent, MouseEvent, PointerEvent))]
 pub struct PointerOutEvent( Reference );
 
@@ -312,7 +312,7 @@ impl ConcreteEvent for PointerOutEvent {
 /// [(JavaScript docs)](https://developer.mozilla.org/en-US/docs/Web/Events/pointerleave)
 // https://w3c.github.io/pointerevents/#the-pointerleave-event
 #[derive(Clone, Debug, PartialEq, Eq, ReferenceType)]
-#[reference(instance_of = "PointerEvent")] // TODO: Better type check.
+#[reference(instance_of = "PointerEvent", constraint="type=pointerleave")]
 #[reference(subclass_of(Event, UiEvent, MouseEvent, PointerEvent))]
 pub struct PointerLeaveEvent( Reference );
 
@@ -329,7 +329,7 @@ impl ConcreteEvent for PointerLeaveEvent {
 /// [(JavaScript docs)](https://developer.mozilla.org/en-US/docs/Web/Events/gotpointercapture)
 // https://w3c.github.io/pointerevents/#the-gotpointercapture-event
 #[derive(Clone, Debug, PartialEq, Eq, ReferenceType)]
-#[reference(instance_of = "PointerEvent")] // TODO: Better type check.
+#[reference(instance_of = "PointerEvent", constraint="type=gotpointercapture")]
 #[reference(subclass_of(Event, UiEvent, MouseEvent, PointerEvent))]
 pub struct GotPointerCaptureEvent( Reference );
 
@@ -346,7 +346,7 @@ impl ConcreteEvent for GotPointerCaptureEvent {
 /// [(JavaScript docs)](https://developer.mozilla.org/en-US/docs/Web/Events/lostpointercapture)
 // https://w3c.github.io/pointerevents/#the-lostpointercapture-event
 #[derive(Clone, Debug, PartialEq, Eq, ReferenceType)]
-#[reference(instance_of = "PointerEvent")] // TODO: Better type check.
+#[reference(instance_of = "PointerEvent", constraint="type=lostpointercapture")]
 #[reference(subclass_of(Event, UiEvent, MouseEvent, PointerEvent))]
 pub struct LostPointerCaptureEvent( Reference );
 

--- a/src/webapi/events/progress.rs
+++ b/src/webapi/events/progress.rs
@@ -60,7 +60,7 @@ impl IProgressEvent for ProgressRelatedEvent {}
 /// [(JavaScript docs)](https://developer.mozilla.org/en-US/docs/Web/Events/progress)
 // https://xhr.spec.whatwg.org/#event-xhr-progress
 #[derive(Clone, Debug, PartialEq, Eq, ReferenceType)]
-#[reference(instance_of = "ProgressEvent")] // TODO: Better type check.
+#[reference(instance_of = "ProgressEvent", constraint="type=progress")]
 #[reference(subclass_of(Event, ProgressRelatedEvent))]
 pub struct ProgressEvent( Reference );
 
@@ -75,7 +75,7 @@ impl ConcreteEvent for ProgressEvent {
 /// [(JavaScript docs)](https://developer.mozilla.org/en-US/docs/Web/Events/load_(ProgressEvent))
 // https://xhr.spec.whatwg.org/#event-xhr-load
 #[derive(Clone, Debug, PartialEq, Eq, ReferenceType)]
-#[reference(instance_of = "ProgressEvent")] // TODO: Better type check.
+#[reference(instance_of = "ProgressEvent", constraint="type=load")]
 #[reference(subclass_of(Event, ProgressRelatedEvent))]
 pub struct ProgressLoadEvent( Reference );
 
@@ -90,7 +90,7 @@ impl ConcreteEvent for ProgressLoadEvent {
 /// [(JavaScript docs)](https://developer.mozilla.org/en-US/docs/Web/Events/loadstart)
 // https://xhr.spec.whatwg.org/#event-xhr-loadstart
 #[derive(Clone, Debug, PartialEq, Eq, ReferenceType)]
-#[reference(instance_of = "ProgressEvent")] // TODO: Better type check.
+#[reference(instance_of = "ProgressEvent", constraint="type=loadstart")]
 #[reference(subclass_of(Event, ProgressRelatedEvent))]
 pub struct LoadStartEvent( Reference );
 
@@ -107,7 +107,7 @@ impl ConcreteEvent for LoadStartEvent {
 /// [(JavaScript docs)](https://developer.mozilla.org/en-US/docs/Web/Events/loadend)
 // https://xhr.spec.whatwg.org/#event-xhr-loadend
 #[derive(Clone, Debug, PartialEq, Eq, ReferenceType)]
-#[reference(instance_of = "ProgressEvent")] // TODO: Better type check.
+#[reference(instance_of = "ProgressEvent", constraint="type=loadend")]
 #[reference(subclass_of(Event, ProgressRelatedEvent))]
 pub struct LoadEndEvent( Reference );
 
@@ -122,7 +122,7 @@ impl ConcreteEvent for LoadEndEvent {
 /// [(JavaScript docs)](https://developer.mozilla.org/en-US/docs/Web/Events/abort_(ProgressEvent))
 // https://xhr.spec.whatwg.org/#event-xhr-abort
 #[derive(Clone, Debug, PartialEq, Eq, ReferenceType)]
-#[reference(instance_of = "ProgressEvent")] // TODO: Better type check.
+#[reference(instance_of = "ProgressEvent", constraint="type=abort")]
 #[reference(subclass_of(Event, ProgressRelatedEvent))]
 pub struct ProgressAbortEvent( Reference );
 
@@ -137,7 +137,7 @@ impl ConcreteEvent for ProgressAbortEvent {
 /// [(JavaScript docs)](https://developer.mozilla.org/en-US/docs/Web/Events/error_(ProgressEvent))
 // https://xhr.spec.whatwg.org/#event-xhr-error
 #[derive(Clone, Debug, PartialEq, Eq, ReferenceType)]
-#[reference(instance_of = "ProgressEvent")] // TODO: Better type check.
+#[reference(instance_of = "ProgressEvent", constraint="type=error")]
 #[reference(subclass_of(Event, ProgressRelatedEvent))]
 pub struct ProgressErrorEvent( Reference );
 

--- a/src/webapi/events/socket.rs
+++ b/src/webapi/events/socket.rs
@@ -12,7 +12,7 @@ use webapi::event::{IEvent, Event, ConcreteEvent};
 /// [(JavaScript docs)](https://developer.mozilla.org/en-US/docs/Web/Events/close)
 // https://html.spec.whatwg.org/multipage/web-sockets.html#closeevent
 #[derive(Clone, Debug, PartialEq, Eq, ReferenceType)]
-#[reference(instance_of = "CloseEvent")] // TODO: Better type check.
+#[reference(instance_of = "CloseEvent", constraint="type=close")]
 #[reference(subclass_of(Event))]
 pub struct SocketCloseEvent( Reference );
 
@@ -63,7 +63,7 @@ impl ConcreteEvent for SocketCloseEvent {
 // https://html.spec.whatwg.org/#event-error
 // https://html.spec.whatwg.org/multipage/web-sockets.html#handler-websocket-onerror
 #[derive(Clone, Debug, PartialEq, Eq, ReferenceType)]
-#[reference(instance_of = "Event")] // TODO: Better type check.
+#[reference(instance_of = "Event", constraint="type=error")]
 #[reference(subclass_of(Event))]
 pub struct SocketErrorEvent( Reference );
 
@@ -78,7 +78,7 @@ impl ConcreteEvent for SocketErrorEvent {
 // https://html.spec.whatwg.org/#event-open
 // https://html.spec.whatwg.org/multipage/web-sockets.html#handler-websocket-onopen
 #[derive(Clone, Debug, PartialEq, Eq, ReferenceType)]
-#[reference(instance_of = "Event")] // TODO: Better type check.
+#[reference(instance_of = "Event", constraint="type=open")]
 #[reference(subclass_of(Event))]
 pub struct SocketOpenEvent( Reference );
 

--- a/stdweb-derive/src/lib.rs
+++ b/stdweb-derive/src/lib.rs
@@ -75,7 +75,7 @@ pub fn derive_reference_type( input: TokenStream ) -> TokenStream {
                         let val = str.value();
                         let parts : Vec<&str> = val.splitn(2,"=").collect();
                         if parts.len() != 2 {
-                            panic!("The value of '#[reference(..., constraint = ...)]' must be in the form of \"js_field=Ident!\"" );
+                            panic!("The value of '#[reference(..., constraint = ...)]' must be in the form of \"js_field=value\"" );
                         }
                         constraints.push(( parts[0].to_owned(), parts[1].to_owned()) );
                     } else {


### PR DESCRIPTION
Re #162

I have amended stdweb-derive such that constraints may be added to the instance_of attribute thus avoiding a bunch of boilerplate. Opted to make this a separate meta item rather than creating additional complexity via nesting.

Go easy on me, I'm pretty new to stdweb ;)