### PR TITLE
fix #199: add Node::from_html

### DIFF
--- a/src/webapi/node.rs
+++ b/src/webapi/node.rs
@@ -363,19 +363,22 @@ impl IEventTarget for Node {}
 impl INode for Node {}
 
 impl Node {
-    /// Attempt to create the `Node` from raw html.
+    /// Attempt to create the `Node` from raw html. The html string must contain **exactly one**
+    /// root node.
     ///
-    /// # Panics
+    /// Returns a `SyntaxError` if:
     ///
-    /// This method panics if the resulting number of nodes != 1. To ensure this
-    /// it is recommended to at _least_ have programatic control of your root
-    /// HTML node.
+    /// - There is not **exactly one** root node.
+    /// - The html syntax is wrong. However, on most browsers the html parsing algorighm is
+    ///   _unbelievably_ forgiving and will just turn your html into text or maybe even an empty
+    ///   string.
     ///
-    /// # Examples
+    /// It is recommended to have control over the html being given to this function as not
+    /// having control is a security concern.
     ///
-    /// ```
-    /// let node = Node::from_html("<div>Some text, horray!</div>").unwrap();
-    /// ```
+    /// For more details, see information about setting `innerHTML`:
+    ///
+    /// <https://developer.mozilla.org/en-US/docs/Web/API/Element/innerHTML>
     pub fn from_html(html: &str) -> Result<Node, SyntaxError> {
         js_try!(
             var span = document.createElement("span");

--- a/src/webapi/node.rs
+++ b/src/webapi/node.rs
@@ -363,11 +363,14 @@ impl IEventTarget for Node {}
 impl INode for Node {}
 
 impl Node {
+    /// Attempt to create the `Node` from raw html.
+    ///
+    /// Note that this uses a `span` node as the parent.
     pub fn from_html(html: &str) -> Result<Node, ConversionError> {
         Node::try_from(js! {
-            var div = document.createElement("div");
-            div.innerHTML = @{html};
-            return div;
+            var span = document.createElement("span");
+            span.innerHTML = @{html};
+            return span;
         })
     }
 }
@@ -826,7 +829,7 @@ mod tests {
         let inner = node.first_child().unwrap();
         let text = inner.first_child().unwrap();
 
-        assert_eq!(node.node_name(), "DIV");
+        assert_eq!(node.node_name(), "SPAN");
         assert_eq!(node.last_child().unwrap(), inner);
 
         assert_eq!(inner.node_name(), "DIV");

--- a/src/webapi/node.rs
+++ b/src/webapi/node.rs
@@ -381,7 +381,10 @@ impl Node {
             var span = document.createElement("span");
             span.innerHTML = @{html};
             if( span.childNodes.length != 1 ) {
-                throw SyntaxError("HTML had ${span.childNodes.length} nodes but must have 1");
+                throw SyntaxError(
+                    "Node::from_html requires a single root node but has: "
+                    + toString(span.childNodes.length)
+                );
             }
             return span.childNodes[0];
         ).unwrap();

--- a/src/webapi/node.rs
+++ b/src/webapi/node.rs
@@ -378,15 +378,12 @@ impl Node {
     /// ```
     pub fn from_html(html: &str) -> Result<Node, SyntaxError> {
         let result: Result<Value, Value> = js_try!(
-            var xmldoc = document.implementation.createDocument(null, null);
-            var span = xmldoc.createElement("span");
+            var span = document.createElement("span");
             span.innerHTML = @{html};
-
             if( span.childNodes.length != 1 ) {
                 throw SyntaxError("HTML had ${span.childNodes.length} nodes but must have 1");
             }
             return span.childNodes[0];
-            return "foo";
         ).unwrap();
 
         match result {
@@ -857,7 +854,7 @@ mod tests {
         let node = Node::from_html("<div>Some text, horray!</div>").unwrap();
         let text = node.first_child().unwrap();
 
-        assert_eq!(node.node_name(), "div");
+        assert_eq!(node.node_name(), "DIV");
         assert_eq!(node.last_child().unwrap(), text);
 
         assert_eq!(text.node_name(), "#text");
@@ -865,6 +862,6 @@ mod tests {
         assert!(text.first_child().is_none());
 
         assert!(Node::from_html("<div>foo</div><div>bar</div>").is_err());
-        assert!(Node::from_html("<di").is_err());
+        assert!(Node::from_html("<di").is_ok()); // interpreted as just text
     }
 }

--- a/src/webapi/node.rs
+++ b/src/webapi/node.rs
@@ -857,7 +857,7 @@ mod tests {
         let node = Node::from_html("<div>Some text, horray!</div>").unwrap();
         let text = node.first_child().unwrap();
 
-        assert_eq!(node.node_name(), "DIV");
+        assert_eq!(node.node_name(), "div");
         assert_eq!(node.last_child().unwrap(), text);
 
         assert_eq!(text.node_name(), "#text");

--- a/src/webcore/value.rs
+++ b/src/webcore/value.rs
@@ -166,6 +166,16 @@ pub enum Value {
 }
 
 impl Value {
+    /// Checks whenever the Value is of the Null variant.
+    #[inline]
+    pub fn is_null( &self ) -> bool {
+        if let Value::Null = *self {
+            true
+        } else {
+            false
+        }
+    }
+
     /// Checks whenever the Value is of the Symbol variant.
     #[inline]
     pub fn is_symbol( &self ) -> bool {


### PR DESCRIPTION
fix #199 

Outstanding question:
- Should the "root element" be ~~`div`~~ `span`? 
- Should it be configurable in some way (`id`, let the user specify the `tag`, let the user insert a node?)
- should this be implemented as `Node::set_inner_html` instead (or can we have both)?