### PR TITLE
Futures 0.2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,10 @@ build = "build.rs"
 discard = "1.0.3"
 serde = { version = "1", optional = true }
 serde_json = { version = "1", optional = true }
-futures = { version = "0.1.18", optional = true }
+futures-core = { version = "0.2.0", optional = true }
+futures-channel = { version = "0.2.0", optional = true }
+futures-util = { version = "0.2.0", optional = true }
+lazy_static = { version = "1.0.0", optional = true }
 
 stdweb-derive = { version = "0.4", path = "stdweb-derive" }
 
@@ -26,10 +29,11 @@ serde_json = "1"
 serde_derive = "1"
 
 [features]
-default = ["serde", "serde_json", "futures"]
+default = ["serde", "serde_json"]
 nightly = []
 web_test = []
-experimental_features_which_may_break_on_minor_version_bumps = []
+futures-support = ["futures-core", "futures-channel", "futures-util", "lazy_static"]
+experimental_features_which_may_break_on_minor_version_bumps = ["futures-support"]
 "docs-rs" = []
 
 [target.wasm32-unknown-unknown.dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,6 @@ serde_json = { version = "1", optional = true }
 futures-core = { version = "0.2.0", optional = true }
 futures-channel = { version = "0.2.0", optional = true }
 futures-util = { version = "0.2.0", optional = true }
-lazy_static = { version = "1.0.0", optional = true }
 
 stdweb-derive = { version = "0.4", path = "stdweb-derive" }
 
@@ -32,7 +31,7 @@ serde_derive = "1"
 default = ["serde", "serde_json"]
 nightly = []
 web_test = []
-futures-support = ["futures-core", "futures-channel", "futures-util", "lazy_static"]
+futures-support = ["futures-core", "futures-channel", "futures-util"]
 experimental_features_which_may_break_on_minor_version_bumps = ["futures-support"]
 "docs-rs" = []
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -135,8 +135,18 @@ extern crate stdweb_internal_macros;
 #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
 pub use stdweb_internal_macros::js_export;
 
-#[cfg(feature = "futures")]
-extern crate futures;
+#[cfg(feature = "futures-support")]
+extern crate futures_core;
+
+#[cfg(feature = "futures-support")]
+extern crate futures_util;
+
+#[cfg(feature = "futures-support")]
+extern crate futures_channel;
+
+#[cfg(feature = "futures-support")]
+#[macro_use]
+extern crate lazy_static;
 
 #[macro_use]
 extern crate stdweb_derive;
@@ -181,7 +191,7 @@ pub use webcore::discard::DiscardOnDrop;
 pub use webcore::promise::{Promise, DoneHandle};
 
 #[cfg(all(
-    feature = "futures",
+    feature = "futures-support",
     feature = "experimental_features_which_may_break_on_minor_version_bumps"
 ))]
 pub use webcore::promise_future::PromiseFuture;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -144,10 +144,6 @@ extern crate futures_util;
 #[cfg(feature = "futures-support")]
 extern crate futures_channel;
 
-#[cfg(feature = "futures-support")]
-#[macro_use]
-extern crate lazy_static;
-
 #[macro_use]
 extern crate stdweb_derive;
 

--- a/src/webcore/executor.rs
+++ b/src/webcore/executor.rs
@@ -66,6 +66,8 @@ impl Task {
 
     fn poll( arc: Arc< Self > ) {
         let mut lock = arc.inner.borrow_mut();
+
+        // This is needed in order to borrow disjoint struct fields
         let lock = &mut *lock;
 
         // Take the future so that if we panic it gets dropped
@@ -117,6 +119,7 @@ struct EventLoopInner {
     // This avoids unnecessary allocations and interop overhead
     // by using a Rust queue of pending tasks.
     queue: VecDeque< Arc< Task > >,
+    // TODO handle overflow
     past_sum: usize,
     past_length: usize,
     shrink_counter: usize,

--- a/src/webcore/mod.rs
+++ b/src/webcore/mod.rs
@@ -19,10 +19,10 @@ pub mod reference_type;
 pub mod promise;
 pub mod discard;
 
-#[cfg(feature = "futures")]
+#[cfg(feature = "futures-support")]
 pub mod promise_future;
 
-#[cfg(feature = "futures")]
+#[cfg(feature = "futures-support")]
 pub mod executor;
 
 #[cfg(feature = "nightly")]

--- a/src/webcore/promise.rs
+++ b/src/webcore/promise.rs
@@ -132,7 +132,7 @@ impl Promise {
     #[cfg(feature = "futures-support")]
     pub fn from_future< A >( future: A ) -> Self
         where A: IntoFuture,
-              A::Future: Send + 'static,
+              A::Future: 'static,
               A::Item: JsSerialize,
               A::Error: JsSerialize {
 
@@ -144,7 +144,7 @@ impl Promise {
         }
 
         let callback = move |success: Reference, error: Reference| {
-            PromiseFuture::spawn(
+            PromiseFuture::spawn_local(
                 future.then( move |result| {
                     match result {
                         Ok( a ) => call( success, a ),

--- a/src/webcore/promise.rs
+++ b/src/webcore/promise.rs
@@ -5,16 +5,19 @@ use webcore::value::{Value, Reference};
 use webcore::try_from::{TryInto, TryFrom};
 use webcore::discard::DiscardOnDrop;
 
-#[cfg(feature = "futures")]
+#[cfg(feature = "futures-support")]
 use webcore::serialization::JsSerialize;
 
-#[cfg(feature = "futures")]
-use futures::unsync::oneshot::channel;
+#[cfg(feature = "futures-support")]
+use futures_channel::oneshot::channel;
 
-#[cfg(feature = "futures")]
-use futures::future::Future;
+#[cfg(feature = "futures-support")]
+use futures_core::IntoFuture;
 
-#[cfg(feature = "futures")]
+#[cfg(feature = "futures-support")]
+use futures_util::FutureExt;
+
+#[cfg(feature = "futures-support")]
 use super::promise_future::PromiseFuture;
 
 
@@ -103,7 +106,7 @@ impl Promise {
     /// If you simply want to use a JavaScript Promise inside Rust, then you
     /// don't need to use this function: you should use
     /// [`PromiseFuture`](struct.PromiseFuture.html) and the
-    /// [`Future`](https://docs.rs/futures/0.1.*/futures/future/trait.Future.html)
+    /// [`FutureExt`](https://docs.rs/futures/0.2.*/futures/future/trait.FutureExt.html)
     /// methods instead.
     ///
     /// # Examples
@@ -126,11 +129,14 @@ impl Promise {
     ///
     /// [(JavaScript docs)](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise#Syntax)
     // https://www.ecma-international.org/ecma-262/6.0/#sec-promise-executor
-    #[cfg(feature = "futures")]
+    #[cfg(feature = "futures-support")]
     pub fn from_future< A >( future: A ) -> Self
-        where A: Future + 'static,
+        where A: IntoFuture,
+              A::Future: Send + 'static,
               A::Item: JsSerialize,
               A::Error: JsSerialize {
+
+        let future = future.into_future();
 
         #[inline]
         fn call< A: JsSerialize >( f: Reference, value: A ) {
@@ -259,7 +265,7 @@ impl Promise {
 
     /// This method should rarely be needed, instead use [`value.try_into()`](unstable/trait.TryInto.html) to convert directly from a [`Value`](enum.Value.html) into a [`PromiseFuture`](struct.PromiseFuture.html).
     ///
-    /// This method converts the `Promise` into a [`PromiseFuture`](struct.PromiseFuture.html), so that it can be used as a Rust [`Future`](https://docs.rs/futures/0.1.*/futures/future/trait.Future.html).
+    /// This method converts the `Promise` into a [`PromiseFuture`](struct.PromiseFuture.html), so that it can be used as a Rust [`Future`](https://docs.rs/futures/0.2.*/futures/future/trait.Future.html).
     ///
     /// # Examples
     ///
@@ -268,7 +274,7 @@ impl Promise {
     /// ```
     // We can't use the IntoFuture trait because Promise doesn't have a type argument
     // TODO explain more why we can't use the IntoFuture trait
-    #[cfg(feature = "futures")]
+    #[cfg(feature = "futures-support")]
     pub fn to_future< A, B >( &self ) -> PromiseFuture< A, B >
          where A: TryFrom< Value > + 'static,
                B: TryFrom< Value > + 'static,

--- a/src/webcore/promise.rs
+++ b/src/webcore/promise.rs
@@ -263,9 +263,9 @@ impl Promise {
         } )
     }
 
-    /// This method should rarely be needed, instead use [`value.try_into()`](unstable/trait.TryInto.html) to convert directly from a [`Value`](enum.Value.html) into a [`PromiseFuture`](struct.PromiseFuture.html).
-    ///
     /// This method converts the `Promise` into a [`PromiseFuture`](struct.PromiseFuture.html), so that it can be used as a Rust [`Future`](https://docs.rs/futures/0.2.*/futures/future/trait.Future.html).
+    ///
+    /// This method should rarely be needed, instead use [`value.try_into()`](unstable/trait.TryInto.html) to convert directly from a [`Value`](enum.Value.html) into a [`PromiseFuture`](struct.PromiseFuture.html).
     ///
     /// # Examples
     ///

--- a/src/webcore/promise_future.rs
+++ b/src/webcore/promise_future.rs
@@ -2,14 +2,15 @@ use std;
 use webcore::value::{Value, ConversionError};
 use webcore::try_from::{TryInto, TryFrom};
 use webapi::error;
-use futures::{Future, Poll, Async};
-use futures::unsync::oneshot::Receiver;
+use futures_core::{Future, Poll, Async, Never};
+use futures_core::task::Context;
+use futures_channel::oneshot::Receiver;
 use webcore::executor::spawn;
 use webcore::discard::DiscardOnDrop;
 use super::promise::{Promise, DoneHandle};
 
 
-/// This allows you to use a JavaScript [`Promise`](struct.Promise.html) as if it is a Rust [`Future`](https://docs.rs/futures/0.1.*/futures/future/trait.Future.html).
+/// This allows you to use a JavaScript [`Promise`](struct.Promise.html) as if it is a Rust [`Future`](https://docs.rs/futures/0.2.*/futures/future/trait.Future.html).
 ///
 /// The preferred way to create a `PromiseFuture` is to use [`value.try_into()`](unstable/trait.TryInto.html) on a JavaScript [`Value`](enum.Value.html).
 ///
@@ -26,19 +27,21 @@ pub struct PromiseFuture< Value, Error = error::Error > {
 }
 
 impl PromiseFuture< (), () > {
-    /// Asynchronously runs the [`Future`](https://docs.rs/futures/0.1.*/futures/future/trait.Future.html) and then immediately returns.
-    /// This does not block the current thread. The only way to retrieve the value of the future is to use the various
-    /// [`Future`](https://docs.rs/futures/0.1.*/futures/future/trait.Future.html) methods, such as
-    /// [`map`](https://docs.rs/futures/0.1.*/futures/future/trait.Future.html#method.map) or
-    /// [`inspect`](https://docs.rs/futures/0.1.*/futures/future/trait.Future.html#method.inspect).
-    ///
-    /// This function requires you to handle all errors yourself. Because the errors happen asynchronously, the only way to catch them is
-    /// to use a [`Future`](https://docs.rs/futures/0.1.*/futures/future/trait.Future.html) method, such as
-    /// [`map_err`](https://docs.rs/futures/0.1.*/futures/future/trait.Future.html#method.map_err).
-    ///
-    /// It is very common to want to print the errors to the console. You can do that by using `.map_err(|e| console!(error, e))`
+    /// Asynchronously runs the [`Future`](https://docs.rs/futures/0.2.*/futures/future/trait.Future.html) and then immediately returns.
+    /// This does *not* block the current thread.
     ///
     /// This function is normally called once in `main`, it is usually not needed to call it multiple times.
+    ///
+    /// The only way to retrieve the value of the future is to use the various
+    /// [`FutureExt`](https://docs.rs/futures/0.2.*/futures/future/trait.FutureExt.html) methods, such as
+    /// [`map`](https://docs.rs/futures/0.2.*/futures/future/trait.FutureExt.html#method.map) or
+    /// [`inspect`](https://docs.rs/futures/0.2.*/futures/future/trait.FutureExt.html#method.inspect).
+    ///
+    /// In addition, you must handle all errors yourself. Because the errors happen asynchronously, the only way to catch them is
+    /// to use a [`FutureExt`](https://docs.rs/futures/0.2.*/futures/future/trait.FutureExt.html) method, such as
+    /// [`map_err`](https://docs.rs/futures/0.2.*/futures/future/trait.FutureExt.html#method.map_err).
+    ///
+    /// It is very common to want to print the errors to the console. You can do that by using `.map_err(|e| console!(error, e))`
     ///
     /// # Examples
     ///
@@ -77,14 +80,14 @@ impl PromiseFuture< (), () > {
     /// ```
     #[inline]
     pub fn spawn< B >( future: B ) where
-        B: Future< Item = (), Error = () > + 'static {
+        B: Future< Item = (), Error = Never > + 'static + Send {
         spawn( future );
     }
 }
 
 impl< A, B > std::fmt::Debug for PromiseFuture< A, B > {
     fn fmt( &self, formatter: &mut std::fmt::Formatter ) -> std::fmt::Result {
-        write!( formatter, "PromiseFuture" )
+        formatter.debug_struct( "PromiseFuture" ).finish()
     }
 }
 
@@ -92,12 +95,12 @@ impl< A, B > Future for PromiseFuture< A, B > {
     type Item = A;
     type Error = B;
 
-    fn poll( &mut self ) -> Poll< Self::Item, Self::Error > {
+    fn poll( &mut self, cx: &mut Context ) -> Poll< Self::Item, Self::Error > {
         // TODO maybe remove this unwrap ?
-        match self.future.poll().unwrap() {
+        match self.future.poll( cx ).unwrap() {
             Async::Ready( Ok( a ) ) => Ok( Async::Ready( a ) ),
             Async::Ready( Err( e ) ) => Err( e ),
-            Async::NotReady => Ok( Async::NotReady ),
+            Async::Pending => Ok( Async::Pending ),
         }
     }
 }

--- a/src/webcore/promise_future.rs
+++ b/src/webcore/promise_future.rs
@@ -42,7 +42,7 @@ impl PromiseFuture< (), Never > {
     /// to use a [`FutureExt`](https://docs.rs/futures/0.2.*/futures/future/trait.FutureExt.html) method, such as
     /// [`map_err`](https://docs.rs/futures/0.2.*/futures/future/trait.FutureExt.html#method.map_err).
     ///
-    /// It is very common to want to print the errors to the console. You can do that by using `.map_err(PromiseFuture::print_error)`
+    /// It is very common to want to print the errors to the console. You can do that by using `.map_err(PromiseFuture::print_error_panic)`
     ///
     /// # Examples
     ///
@@ -52,7 +52,7 @@ impl PromiseFuture< (), Never > {
     /// fn main() {
     ///     PromiseFuture::spawn_local(
     ///         create_some_future()
-    ///             .map_err(PromiseFuture::print_error)
+    ///             .map_err(PromiseFuture::print_error_panic)
     ///     );
     /// }
     /// ```
@@ -66,7 +66,7 @@ impl PromiseFuture< (), Never > {
     ///             .map(|x| {
     ///                 println!("Future finished with value: {:#?}", x);
     ///             })
-    ///             .map_err(PromiseFuture::print_error)
+    ///             .map_err(PromiseFuture::print_error_panic)
     ///     );
     /// }
     /// ```
@@ -94,7 +94,7 @@ impl PromiseFuture< (), Never > {
     /// # Panics
     /// This function *always* panics.
     #[inline]
-    pub fn print_error< A: JsSerialize >( value: A ) -> Never {
+    pub fn print_error_panic< A: JsSerialize >( value: A ) -> Never {
         js! { @(no_return)
             console.error( @{value} );
         }

--- a/src/webcore/promise_future.rs
+++ b/src/webcore/promise_future.rs
@@ -85,9 +85,12 @@ impl PromiseFuture< (), Never > {
         spawn_local( future );
     }
 
-    /// This is used to print an error to the console.
+    /// Prints an error to the console and then panics.
     ///
     /// See the documentation for [`spawn_local`](#method.spawn_local) for more details.
+    ///
+    /// # Panics
+    /// This function *always* panics.
     #[inline]
     pub fn print_error< A: JsSerialize >( value: A ) -> Never {
         js! { @(no_return)

--- a/src/webcore/promise_future.rs
+++ b/src/webcore/promise_future.rs
@@ -5,7 +5,7 @@ use webapi::error;
 use futures_core::{Future, Poll, Async, Never};
 use futures_core::task::Context;
 use futures_channel::oneshot::Receiver;
-use webcore::executor::spawn;
+use webcore::executor::spawn_local;
 use webcore::discard::DiscardOnDrop;
 use super::promise::{Promise, DoneHandle};
 
@@ -26,9 +26,9 @@ pub struct PromiseFuture< Value, Error = error::Error > {
     pub(crate) _done_handle: DiscardOnDrop< DoneHandle >,
 }
 
-impl PromiseFuture< (), () > {
-    /// Asynchronously runs the [`Future`](https://docs.rs/futures/0.2.*/futures/future/trait.Future.html) and then immediately returns.
-    /// This does *not* block the current thread.
+impl PromiseFuture< (), Never > {
+    /// Asynchronously runs the [`Future`](https://docs.rs/futures/0.2.*/futures/future/trait.Future.html) on the current thread
+    /// and then immediately returns. This does *not* block the current thread.
     ///
     /// This function is normally called once in `main`, it is usually not needed to call it multiple times.
     ///
@@ -49,7 +49,7 @@ impl PromiseFuture< (), () > {
     ///
     /// ```rust
     /// fn main() {
-    ///     PromiseFuture::spawn(
+    ///     PromiseFuture::spawn_local(
     ///         create_some_future()
     ///             .map_err(|e| console!(error, e))
     ///     );
@@ -60,7 +60,7 @@ impl PromiseFuture< (), () > {
     ///
     /// ```rust
     /// fn main() {
-    ///     PromiseFuture::spawn(
+    ///     PromiseFuture::spawn_local(
     ///         create_some_future()
     ///             .inspect(|x| println!("Future finished: {:#?}", x))
     ///             .map_err(|e| console!(error, e))
@@ -72,16 +72,16 @@ impl PromiseFuture< (), () > {
     ///
     /// ```rust
     /// fn main() {
-    ///     PromiseFuture::spawn(
+    ///     PromiseFuture::spawn_local(
     ///         create_some_future()
     ///             .map_err(|e| handle_error_somehow(e))
     ///     );
     /// }
     /// ```
     #[inline]
-    pub fn spawn< B >( future: B ) where
-        B: Future< Item = (), Error = Never > + 'static + Send {
-        spawn( future );
+    pub fn spawn_local< B >( future: B ) where
+        B: Future< Item = (), Error = Never > + 'static {
+        spawn_local( future );
     }
 }
 

--- a/src/webcore/promise_future.rs
+++ b/src/webcore/promise_future.rs
@@ -57,13 +57,15 @@ impl PromiseFuture< (), Never > {
     /// }
     /// ```
     ///
-    /// Inspect the output value of the future:
+    /// Use the output value of the future:
     ///
     /// ```rust
     /// fn main() {
     ///     PromiseFuture::spawn_local(
     ///         create_some_future()
-    ///             .inspect(|x| println!("Future finished: {:#?}", x))
+    ///             .map(|x| {
+    ///                 println!("Future finished with value: {:#?}", x);
+    ///             })
     ///             .map_err(PromiseFuture::print_error)
     ///     );
     /// }


### PR DESCRIPTION
I've tested that it works, and the performance is the same as the old executor.

Breaking changes:

* `PromiseFuture::spawn` has been renamed to `PromiseFuture::spawn_local` (for consistency with LocalExecutor)

* `PromiseFuture::spawn_local` now requires the error type to be `Never` (it used to be `()`)