### PR TITLE
Export SocketMessageData

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -335,7 +335,8 @@ pub mod web {
             SocketCloseEvent,
             SocketErrorEvent,
             SocketOpenEvent,
-            SocketMessageEvent
+            SocketMessageEvent,
+            SocketMessageData
         };
 
         pub use webapi::events::history::{


### PR DESCRIPTION
It is necessary to detect different kinds of incoming data.

**Extra:** consider using trailing comma for last elements, it reduces lines in diffs.