### PR TITLE
Add Gamepad API

### DIFF
--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -1,2 +1,2 @@
 [workspace]
-members = ["canvas", "echo", "hasher", "minimal", "todomvc", "webgl"]
+members = ["canvas", "echo", "gamepad", "hasher", "minimal", "todomvc", "webgl"]

--- a/examples/gamepad/Cargo.toml
+++ b/examples/gamepad/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "gamepad"
+version = "0.1.0"
+authors = ["Cory Sherman <coryshrmn@gmail.com>"]
+
+[dependencies]
+stdweb = { path = "../.." }

--- a/examples/gamepad/src/main.rs
+++ b/examples/gamepad/src/main.rs
@@ -1,0 +1,33 @@
+#[macro_use]
+extern crate stdweb;
+
+use stdweb::web::{
+    IEventTarget,
+    IGamepad,
+    window,
+};
+
+use stdweb::web::event::{
+    GamepadConnectedEvent,
+    IGamepadEvent,
+};
+
+fn main() {
+    stdweb::initialize();
+
+    let message = "hello rust!";
+
+    js! {
+        alert( @{message} );
+    }
+
+    window().add_event_listener( move |e: GamepadConnectedEvent| {
+        let message = format!("gamepad \"{}\" connected in rust!", e.gamepad().id());
+
+        js! {
+            alert( @{message} );
+        }
+    });
+
+    stdweb::event_loop();
+}

--- a/examples/gamepad/src/main.rs
+++ b/examples/gamepad/src/main.rs
@@ -108,7 +108,7 @@ fn get_pad_state(pad: &Option<Gamepad>) -> Element {
 fn animate() {
     let list = document().create_element("ul").unwrap();
 
-    for pad in Gamepad::get_gamepads() {
+    for pad in Gamepad::get_all() {
         let item = document().create_element("li").unwrap();
         item.append_child(&get_pad_state(&pad));
         list.append_child(&item);

--- a/examples/gamepad/src/main.rs
+++ b/examples/gamepad/src/main.rs
@@ -1,32 +1,133 @@
-#[macro_use]
 extern crate stdweb;
 
+use std::rc::Rc;
+use std::cell::RefCell;
+
+use stdweb::traits::*;
+use stdweb::unstable::TryInto;
 use stdweb::web::{
+    document,
+    Gamepad,
+    GamepadMappingType,
+    HtmlElement,
     IEventTarget,
     IGamepad,
+    IGamepadButton,
     window,
 };
-
 use stdweb::web::event::{
     GamepadConnectedEvent,
+    GamepadDisconnectedEvent,
     IGamepadEvent,
 };
+
+fn log(msg: &str) {
+    let log_div: HtmlElement = document().query_selector( ".log" ).unwrap().unwrap().try_into().unwrap();
+
+    let p = document().create_element("p").unwrap();
+    p.set_text_content(msg);
+    log_div.append_child(&p);
+}
+
+struct State {
+    gamepads: Vec<Gamepad>,
+    div: HtmlElement,
+}
+
+impl State {
+
+    fn new(div: HtmlElement) -> Self {
+        Self {
+            gamepads: vec![],
+            div,
+        }
+    }
+
+    fn add(&mut self, pad: Gamepad) {
+        self.gamepads.push(pad);
+    }
+
+    fn remove(&mut self, pad: Gamepad) {
+        self.gamepads.retain(|p| p.index() != pad.index());
+    }
+
+    fn animate(&self, rc: Rc<RefCell<Self>>) {
+
+        let list = document().create_element("ul").unwrap();
+
+        for (i, pad) in self.gamepads.iter().enumerate() {
+            let item = document().create_element("li").unwrap();
+
+            let title = format!("pad[{}] \"{}\" {}; {} mapping; last update = {:.0}",
+                i,
+                pad.id(),
+                if pad.connected() { "connected" } else { "disconnected" },
+                match pad.mapping() { GamepadMappingType::Standard => "standard", _ => "nonstandard" },
+                pad.timestamp()
+            );
+
+            let title_p = document().create_element("p").unwrap();
+            title_p.set_text_content(&title);
+
+            item.append_child(&title_p);
+
+            for (i, a) in pad.axes().into_iter().enumerate() {
+                let axis = document().create_element("p").unwrap();
+                axis.set_text_content(&format!("axis[{}] = {}", i, a));
+                item.append_child(&axis);
+            }
+
+            for (i, b) in pad.buttons().into_iter().enumerate() {
+                let button = document().create_element("p").unwrap();
+                button.set_text_content(&format!("button[{}] pressed = {}; value = {}",
+                    i,
+                    b.pressed(),
+                    b.value()
+                ));
+                item.append_child(&button);
+            }
+
+            list.append_child(&item);
+        }
+
+        self.div.set_text_content("");
+        self.div.append_child(&list);
+
+        window().request_animation_frame(move |_| {
+            rc.borrow().animate(rc.clone());
+        });
+    }
+}
 
 fn main() {
     stdweb::initialize();
 
-    let message = "hello rust!";
+    log("Waiting for gamepad connection...");
 
-    js! {
-        alert( @{message} );
-    }
+    let state_div: HtmlElement = document().query_selector( ".state" ).unwrap().unwrap().try_into().unwrap();
+
+    let state_rc = Rc::new(RefCell::new(State::new(state_div)));
+
+    state_rc.borrow().animate(state_rc.clone());
+
+    let state_rc1 = state_rc.clone();
 
     window().add_event_listener( move |e: GamepadConnectedEvent| {
-        let message = format!("gamepad \"{}\" connected in rust!", e.gamepad().id());
+        let pad = e.gamepad();
 
-        js! {
-            alert( @{message} );
-        }
+        let message = format!("gamepad \"{}\" connected", pad.id());
+        log(&message);
+
+        state_rc1.borrow_mut().add(pad);
+    });
+
+    window().add_event_listener( move |e: GamepadDisconnectedEvent| {
+        let pad = e.gamepad();
+
+        let message = format!("gamepad \"{}\" disconnected", pad.id());
+        log(&message);
+
+        state_rc.borrow_mut().remove(pad);
     });
 
     stdweb::event_loop();

--- a/examples/gamepad/src/main.rs
+++ b/examples/gamepad/src/main.rs
@@ -6,10 +6,7 @@ use stdweb::web::{
     Element,
     Gamepad,
     GamepadMappingType,
-    get_gamepads,
     IEventTarget,
-    IGamepad,
-    IGamepadButton,
     window,
 };
 use stdweb::web::event::{
@@ -111,7 +108,7 @@ fn get_pad_state(pad: &Option<Gamepad>) -> Element {
 fn animate() {
     let list = document().create_element("ul").unwrap();
 
-    for pad in get_gamepads() {
+    for pad in Gamepad::get_gamepads() {
         let item = document().create_element("li").unwrap();
         item.append_child(&get_pad_state(&pad));
         list.append_child(&item);

--- a/examples/gamepad/src/main.rs
+++ b/examples/gamepad/src/main.rs
@@ -1,16 +1,12 @@
 extern crate stdweb;
 
-use std::rc::Rc;
-use std::cell::RefCell;
-
 use stdweb::traits::*;
-use stdweb::unstable::TryInto;
 use stdweb::web::{
     document,
+    Element,
     Gamepad,
     GamepadMappingType,
     get_gamepads,
-    HtmlElement,
     IEventTarget,
     IGamepad,
     IGamepadButton,
@@ -22,85 +18,112 @@ use stdweb::web::event::{
     IGamepadEvent,
 };
 
+/// Create an element and set its content.
+fn elem_content(elem_type: &str, content: &str) -> Element {
+    let elem = document().create_element(elem_type).unwrap();
+    elem.set_text_content(content);
+    elem
+}
+
+/// Write a new line to the "log" div.
 fn log(msg: &str) {
-    let log_div: HtmlElement = document().query_selector( ".log" ).unwrap().unwrap().try_into().unwrap();
+    let log_div = document().query_selector("#log").unwrap().unwrap();
 
-    let p = document().create_element("p").unwrap();
-    p.set_text_content(msg);
-    log_div.append_child(&p);
+    log_div.append_child(&elem_content("p", msg));
 }
 
-struct State {
-    gamepads: Vec<Gamepad>,
-    div: HtmlElement,
+fn get_pad_title(pad: &Gamepad) -> Element {
+    let div = document().create_element("div").unwrap();
+
+    div.append_child(&elem_content("h2",
+        &format!("Pad {}: {}", pad.index(), pad.id())
+    ));
+
+    div.append_child(&elem_content("h3",
+        if pad.connected() { "Connected" } else { "Disconnected" }
+    ));
+
+    div.append_child(&elem_content("h3",
+        &format!("Mapping: {}", match pad.mapping() { GamepadMappingType::Standard => "standard", _ => "non-standard" })
+    ));
+
+    div.append_child(&elem_content("h3",
+        &format!("Last updated: {:.0}", pad.timestamp())
+    ));
+
+    div
 }
 
-impl State {
+fn get_pad_axes(pad: &Gamepad) -> Element {
+    let div = document().create_element("div").unwrap();
 
-    fn new(div: HtmlElement) -> Self {
-        Self {
-            gamepads: vec![],
-            div,
+    for (i, a) in pad.axes().into_iter().enumerate() {
+        let elem = elem_content("p",
+            &format!("Axis {}: {}", i, a)
+        );
+
+        if a != 0.0 {
+            elem.set_attribute("class", "gp-pressed").unwrap();
+        }
+
+        div.append_child(&elem);
+    }
+
+    div
+}
+
+fn get_pad_buttons(pad: &Gamepad) -> Element {
+    let div = document().create_element("div").unwrap();
+
+    for (i, b) in pad.buttons().into_iter().enumerate() {
+        let elem = elem_content("p",
+            &format!("Button {}: Pressed = {}; Value = {}", i, b.pressed(), b.value())
+        );
+
+        if b.value() != 0.0 {
+            elem.set_attribute("class", "gp-pressed").unwrap();
+        }
+
+        div.append_child(&elem);
+    }
+
+    div
+}
+
+fn get_pad_state(pad: &Option<Gamepad>) -> Element {
+    let elem = document().create_element("div").unwrap();
+
+    match pad {
+        Some(pad) => {
+            elem.append_child(&get_pad_title(&pad));
+            elem.append_child(&get_pad_axes(&pad));
+            elem.append_child(&get_pad_buttons(&pad));
+        },
+        None => {
+            elem.append_child(&elem_content("h2", "No pad"));
         }
     }
 
-    fn add(&mut self, pad: Gamepad) {
-        self.gamepads.push(pad);
+    elem
+}
+
+/// Update gamepad state view
+fn animate() {
+    let list = document().create_element("ul").unwrap();
+
+    for pad in get_gamepads() {
+        let item = document().create_element("li").unwrap();
+        item.append_child(&get_pad_state(&pad));
+        list.append_child(&item);
     }
 
-    fn remove(&mut self, pad: Gamepad) {
-        self.gamepads.retain(|p| p.index() != pad.index());
-    }
+    let state = document().query_selector("#state").unwrap().unwrap();
 
-    fn animate(&self, rc: Rc<RefCell<Self>>) {
+    state.set_text_content("");
+    state.append_child(&list);
 
-        // Chrome only updates Gamepad state when getGamepads is called
-        get_gamepads();
-
-        let list = document().create_element("ul").unwrap();
-
-        for (i, pad) in self.gamepads.iter().enumerate() {
-            let item = document().create_element("li").unwrap();
-
-            let title = format!("pad[{}] \"{}\" {}; {} mapping; last update = {:.0}",
-                i,
-                pad.id(),
-                if pad.connected() { "connected" } else { "disconnected" },
-                match pad.mapping() { GamepadMappingType::Standard => "standard", _ => "nonstandard" },
-                pad.timestamp()
-            );
-
-            let title_p = document().create_element("p").unwrap();
-            title_p.set_text_content(&title);
-
-            item.append_child(&title_p);
-
-            for (i, a) in pad.axes().into_iter().enumerate() {
-                let axis = document().create_element("p").unwrap();
-                axis.set_text_content(&format!("axis[{}] = {}", i, a));
-                item.append_child(&axis);
-            }
-
-            for (i, b) in pad.buttons().into_iter().enumerate() {
-                let button = document().create_element("p").unwrap();
-                button.set_text_content(&format!("button[{}] pressed = {}; value = {}",
-                    i,
-                    b.pressed(),
-                    b.value()
-                ));
-                item.append_child(&button);
-            }
-
-            list.append_child(&item);
-        }
-
-        self.div.set_text_content("");
-        self.div.append_child(&list);
-
-        window().request_animation_frame(move |_| {
-            rc.borrow().animate(rc.clone());
-        });
-    }
+    // queue another animate() on the next frame
+    window().request_animation_frame(|_| animate());
 }
 
 fn main() {
@@ -108,30 +131,18 @@ fn main() {
 
     log("Waiting for gamepad connection...");
 
-    let state_div: HtmlElement = document().query_selector( ".state" ).unwrap().unwrap().try_into().unwrap();
-
-    let state_rc = Rc::new(RefCell::new(State::new(state_div)));
-
-    state_rc.borrow().animate(state_rc.clone());
-
-    let state_rc1 = state_rc.clone();
+    animate();
 
     window().add_event_listener( move |e: GamepadConnectedEvent| {
         let pad = e.gamepad();
-
         let message = format!("gamepad \"{}\" connected", pad.id());
         log(&message);
-
-        state_rc1.borrow_mut().add(pad);
     });
 
     window().add_event_listener( move |e: GamepadDisconnectedEvent| {
         let pad = e.gamepad();
-
         let message = format!("gamepad \"{}\" disconnected", pad.id());
         log(&message);
-
-        state_rc.borrow_mut().remove(pad);
     });
 
     stdweb::event_loop();

--- a/examples/gamepad/src/main.rs
+++ b/examples/gamepad/src/main.rs
@@ -9,6 +9,7 @@ use stdweb::web::{
     document,
     Gamepad,
     GamepadMappingType,
+    get_gamepads,
     HtmlElement,
     IEventTarget,
     IGamepad,
@@ -52,6 +53,9 @@ impl State {
     }
 
     fn animate(&self, rc: Rc<RefCell<Self>>) {
+
+        // Chrome only updates Gamepad state when getGamepads is called
+        get_gamepads();
 
         let list = document().create_element("ul").unwrap();
 

--- a/examples/gamepad/static/index.html
+++ b/examples/gamepad/static/index.html
@@ -1,0 +1,14 @@
+<!doctype html>
+<html lang="en">
+    <head>
+        <meta charset="utf-8">
+        <title>stdweb • Gamepad</title>
+    </head>
+    <body>
+        <div class="state">
+        </div>
+        <div class="log">
+        </div>
+        <script src="gamepad.js"></script>
+    </body>
+</html>

--- a/examples/gamepad/static/index.html
+++ b/examples/gamepad/static/index.html
@@ -3,11 +3,19 @@
     <head>
         <meta charset="utf-8">
         <title>stdweb • Gamepad</title>
+        <style>
+            .gp-pressed {
+                background-color: black;
+                color: white;
+            }
+        </style>
     </head>
     <body>
-        <div class="state">
+        <h1>Gamepad State</h1>
+        <div id="state">
         </div>
-        <div class="log">
+        <h1>Connection Log</h1>
+        <div id="log">
         </div>
         <script src="gamepad.js"></script>
     </body>

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -243,7 +243,7 @@ pub mod web {
     pub use webapi::blob::{IBlob, Blob};
     pub use webapi::html_collection::HtmlCollection;
     pub use webapi::child_node::IChildNode;
-    pub use webapi::gamepad::{Gamepad, GamepadButton, GamepadMappingType, get_gamepads, IGamepad, IGamepadButton};
+    pub use webapi::gamepad::{Gamepad, GamepadButton, GamepadMappingType};
 
     /// A module containing error types.
     pub mod error {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -243,6 +243,7 @@ pub mod web {
     pub use webapi::blob::{IBlob, Blob};
     pub use webapi::html_collection::HtmlCollection;
     pub use webapi::child_node::IChildNode;
+    pub use webapi::gamepad::{IGamepad, Gamepad, GamepadMappingType};
 
     /// A module containing error types.
     pub mod error {
@@ -364,6 +365,12 @@ pub mod web {
             IFocusEvent,
             FocusEvent,
             BlurEvent
+        };
+
+        pub use webapi::events::gamepad::{
+            IGamepadEvent,
+            GamepadConnectedEvent,
+            GamepadDisconnectedEvent,
         };
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -243,7 +243,7 @@ pub mod web {
     pub use webapi::blob::{IBlob, Blob};
     pub use webapi::html_collection::HtmlCollection;
     pub use webapi::child_node::IChildNode;
-    pub use webapi::gamepad::{IGamepad, Gamepad, GamepadMappingType, IGamepadButton, GamepadButton};
+    pub use webapi::gamepad::{Gamepad, GamepadButton, GamepadMappingType, get_gamepads, IGamepad, IGamepadButton};
 
     /// A module containing error types.
     pub mod error {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -243,7 +243,7 @@ pub mod web {
     pub use webapi::blob::{IBlob, Blob};
     pub use webapi::html_collection::HtmlCollection;
     pub use webapi::child_node::IChildNode;
-    pub use webapi::gamepad::{IGamepad, Gamepad, GamepadMappingType};
+    pub use webapi::gamepad::{IGamepad, Gamepad, GamepadMappingType, IGamepadButton, GamepadButton};
 
     /// A module containing error types.
     pub mod error {

--- a/src/webapi/events/gamepad.rs
+++ b/src/webapi/events/gamepad.rs
@@ -1,0 +1,65 @@
+//use std::fmt::Debug;
+
+use webcore::value::Reference;
+use webcore::try_from::TryInto;
+
+use webapi::event::{IEvent, Event, ConcreteEvent};
+use webapi::gamepad::Gamepad;
+
+/// A GamepadEvent is fired on the window object, when a gamepad is connected or disconnected to the system.
+///
+/// [(JavaScript docs)](https://developer.mozilla.org/en-US/docs/Web/API/GamepadEvent)
+// https://www.w3.org/TR/gamepad/#gamepadevent-interface
+pub trait IGamepadEvent: IEvent {
+
+    /// Returns the gamepad associated with this event.
+    #[inline]
+    fn gamepad( &self ) -> Gamepad {
+        js!(
+            return @{self.as_ref()}.gamepad;
+        ).try_into().unwrap()
+    }
+}
+
+/// A reference to a JavaScript object which implements the [IGamepadEvent](trait.IGamepadEvent.html)
+/// interface.
+///
+/// [(JavaScript docs)](https://developer.mozilla.org/en-US/docs/Web/API/GamepadEvent)
+// https://www.w3.org/TR/gamepad/#gamepadevent-interface
+#[derive(Clone, Debug, Eq, PartialEq, ReferenceType)]
+#[reference(instance_of = "GamepadEvent")]
+#[reference(subclass_of(Event))]
+pub struct GamepadEvent( Reference );
+
+impl IEvent for GamepadEvent {}
+impl IGamepadEvent for GamepadEvent {}
+
+/// The `GamepadConnected` event is fired on the window object, when the first input is received for a gamepad.
+///
+/// [(JavaScript docs)](https://developer.mozilla.org/en-US/docs/Web/Events/gamepadconnected)
+// https://www.w3.org/TR/gamepad/#event-gamepadconnected
+#[derive(Clone, Debug, Eq, PartialEq, ReferenceType)]
+#[reference(instance_of = "GamepadEvent")]
+#[reference(subclass_of(Event, GamepadEvent))]
+pub struct GamepadConnectedEvent( Reference );
+
+impl IEvent for GamepadConnectedEvent {}
+impl IGamepadEvent for GamepadConnectedEvent {}
+impl ConcreteEvent for GamepadConnectedEvent {
+    const EVENT_TYPE: &'static str = "gamepadconnected";
+}
+
+/// The `GamepadDisconnected` event is fired on the window object, when a gamepad is disconnected.
+///
+/// [(JavaScript docs)](https://developer.mozilla.org/en-US/docs/Web/Events/gamepaddisconnected)
+// https://www.w3.org/TR/gamepad/#event-gamepaddisconnected
+#[derive(Clone, Debug, Eq, PartialEq, ReferenceType)]
+#[reference(instance_of = "GamepadEvent")]
+#[reference(subclass_of(Event, GamepadEvent))]
+pub struct GamepadDisconnectedEvent( Reference );
+
+impl IEvent for GamepadDisconnectedEvent {}
+impl IGamepadEvent for GamepadDisconnectedEvent {}
+impl ConcreteEvent for GamepadDisconnectedEvent {
+    const EVENT_TYPE: &'static str = "gamepaddisconnected";
+}

--- a/src/webapi/events/gamepad.rs
+++ b/src/webapi/events/gamepad.rs
@@ -1,5 +1,3 @@
-//use std::fmt::Debug;
-
 use webcore::value::Reference;
 use webcore::try_from::TryInto;
 
@@ -9,7 +7,7 @@ use webapi::gamepad::Gamepad;
 /// A GamepadEvent is fired on the window object, when a gamepad is connected or disconnected to the system.
 ///
 /// [(JavaScript docs)](https://developer.mozilla.org/en-US/docs/Web/API/GamepadEvent)
-// https://www.w3.org/TR/gamepad/#gamepadevent-interface
+// https://w3c.github.io/gamepad/#gamepadevent-interface
 pub trait IGamepadEvent: IEvent {
 
     /// Returns the gamepad associated with this event.
@@ -25,7 +23,7 @@ pub trait IGamepadEvent: IEvent {
 /// interface.
 ///
 /// [(JavaScript docs)](https://developer.mozilla.org/en-US/docs/Web/API/GamepadEvent)
-// https://www.w3.org/TR/gamepad/#gamepadevent-interface
+// https://w3c.github.io/gamepad/#gamepadevent-interface
 #[derive(Clone, Debug, Eq, PartialEq, ReferenceType)]
 #[reference(instance_of = "GamepadEvent")]
 #[reference(subclass_of(Event))]
@@ -37,7 +35,7 @@ impl IGamepadEvent for GamepadEvent {}
 /// The `GamepadConnected` event is fired on the window object, when the first input is received for a gamepad.
 ///
 /// [(JavaScript docs)](https://developer.mozilla.org/en-US/docs/Web/Events/gamepadconnected)
-// https://www.w3.org/TR/gamepad/#event-gamepadconnected
+// https://w3c.github.io/gamepad/#event-gamepadconnected
 #[derive(Clone, Debug, Eq, PartialEq, ReferenceType)]
 #[reference(instance_of = "GamepadEvent")]
 #[reference(subclass_of(Event, GamepadEvent))]
@@ -52,7 +50,7 @@ impl ConcreteEvent for GamepadConnectedEvent {
 /// The `GamepadDisconnected` event is fired on the window object, when a gamepad is disconnected.
 ///
 /// [(JavaScript docs)](https://developer.mozilla.org/en-US/docs/Web/Events/gamepaddisconnected)
-// https://www.w3.org/TR/gamepad/#event-gamepaddisconnected
+// https://w3c.github.io/gamepad/#event-gamepaddisconnected
 #[derive(Clone, Debug, Eq, PartialEq, ReferenceType)]
 #[reference(instance_of = "GamepadEvent")]
 #[reference(subclass_of(Event, GamepadEvent))]

--- a/src/webapi/events/gamepad.rs
+++ b/src/webapi/events/gamepad.rs
@@ -61,3 +61,28 @@ impl IGamepadEvent for GamepadDisconnectedEvent {}
 impl ConcreteEvent for GamepadDisconnectedEvent {
     const EVENT_TYPE: &'static str = "gamepaddisconnected";
 }
+
+#[cfg(all(test, feature = "web_test"))]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_gamepad_connected_event() {
+
+        let event: GamepadConnectedEvent = js!(
+            return new GamepadEvent("gamepadconnected");
+        ).try_into().unwrap();
+
+        assert_eq!(event.event_type(), "gamepadconnected");
+    }
+
+    #[test]
+    fn test_gamepad_disconnected_event() {
+
+        let event: GamepadDisconnectedEvent = js!(
+            return new GamepadEvent("gamepaddisconnected");
+        ).try_into().unwrap();
+
+        assert_eq!(event.event_type(), "gamepaddisconnected");
+    }
+}

--- a/src/webapi/events/mod.rs
+++ b/src/webapi/events/mod.rs
@@ -1,5 +1,6 @@
 pub mod dom;
 pub mod focus;
+pub mod gamepad;
 pub mod history;
 pub mod keyboard;
 pub mod mouse;

--- a/src/webapi/gamepad.rs
+++ b/src/webapi/gamepad.rs
@@ -191,3 +191,27 @@ pub fn get_gamepads() -> Vec<Option<Gamepad>> {
         return Array.from(navigator.getGamepads());
     ).try_into().unwrap()
 }
+
+#[cfg(test)]
+mod tests {
+    use super::GamepadMappingType;
+
+    use webcore::try_from::TryInto;
+    use webcore::value::{ConversionError, Value};
+
+    #[test]
+    fn test_value_into_gamepad_mapping() {
+
+        let to_mapping = |v: Value| -> Result<GamepadMappingType, ConversionError> {
+            v.try_into()
+        };
+
+        assert_eq!(to_mapping("standard".into()), Ok(GamepadMappingType::Standard));
+        assert_eq!(to_mapping("".into()), Ok(GamepadMappingType::NoMapping));
+        assert!(to_mapping("fakemapping".into()).is_err());
+        assert!(to_mapping(Value::Null).is_err());
+    }
+
+    // most of the Gamepad API is not testable,
+    // because Gamepad and GamepadButton are not constructible
+}

--- a/src/webapi/gamepad.rs
+++ b/src/webapi/gamepad.rs
@@ -1,8 +1,15 @@
 //use std::fmt::Debug;
 
 use webcore::reference_type::ReferenceType;
-use webcore::try_from::TryInto;
-use webcore::value::Reference;
+use webcore::try_from::{
+    TryFrom,
+    TryInto,
+};
+use webcore::value::{
+    ConversionError,
+    Reference,
+    Value,
+};
 
 /// The set of known gamepad layout mappings.
 ///
@@ -16,6 +23,72 @@ pub enum GamepadMappingType {
     Standard,
 }
 
+impl TryFrom<Value> for GamepadMappingType {
+    type Error = ConversionError;
+
+    fn try_from(v: Value) -> Result<Self, Self::Error> {
+        match v {
+            Value::String(s) => match s.as_ref() {
+                "" => Ok(GamepadMappingType::NoMapping),
+                "standard" => Ok(GamepadMappingType::Standard),
+                s => Err(ConversionError::Custom(format!("invalid gamepad mapping type \"{}\"", s))),
+            },
+            _ => Err(ConversionError::type_mismatch(&v)),
+        }
+    }
+}
+
+/// The state of an individual button on a gamepad device.
+///
+/// [(JavaScript docs)](https://developer.mozilla.org/en-US/docs/Web/API/GamepadButton)
+// https://w3c.github.io/gamepad/#gamepadbutton-interface
+pub trait IGamepadButton: ReferenceType {
+
+    /// Is the button currently pressed?
+    ///
+    /// [(JavaScript docs)](https://developer.mozilla.org/en-US/docs/Web/API/GamepadButton/pressed)
+    // https://w3c.github.io/gamepad/#dom-gamepadbutton-pressed
+    #[inline]
+    fn pressed(&self) -> bool {
+        js!(
+            return @{self.as_ref()}.pressed;
+        ).try_into().unwrap()
+    }
+
+    /// Is the button currently touched?
+    ///
+    /// MDN does not document this, it may be unsupported by browsers.
+    // https://w3c.github.io/gamepad/#dom-gamepadbutton-touched
+    #[inline]
+    fn touched(&self) -> bool {
+        js!(
+            return @{self.as_ref()}.touched;
+        ).try_into().unwrap()
+    }
+
+    /// The amount which the button has been pressed, between 0.0 (not pressed), and 1.0 (fully pressed).
+    ///
+    /// [(JavaScript docs)](https://developer.mozilla.org/en-US/docs/Web/API/GamepadButton/value)
+    // https://w3c.github.io/gamepad/#dom-gamepadbutton-touched
+    #[inline]
+    fn value(&self) -> f64 {
+        js!(
+            return @{self.as_ref()}.value;
+        ).try_into().unwrap()
+    }
+}
+
+/// A reference to a JavaScript object which implements the [IGamepadButton](trait.IGamepadButton.html)
+/// interface.
+///
+/// [(JavaScript docs)](https://developer.mozilla.org/en-US/docs/Web/API/GamepadButton)
+// https://w3c.github.io/gamepad/#gamepadbutton-interface
+#[derive(Clone, Debug, Eq, PartialEq, ReferenceType)]
+#[reference(instance_of = "GamepadButton")]
+pub struct GamepadButton( Reference );
+
+impl IGamepadButton for GamepadButton {}
+
 /// An individual gamepad/controller.
 ///
 /// [(JavaScript docs)](https://developer.mozilla.org/en-US/docs/Web/API/Gamepad)
@@ -25,7 +98,7 @@ pub trait IGamepad: ReferenceType {
     /// A string containing some information about this gamepad.
     ///
     /// [(JavaScript docs)](https://developer.mozilla.org/en-US/docs/Web/API/Gamepad/id)
-    // https://w3c.github.io/gamepad/#gamepad-interface
+    // https://www.w3.org/TR/gamepad/#dom-gamepad-id
     #[inline]
     fn id(&self) -> String {
         js!(
@@ -33,8 +106,72 @@ pub trait IGamepad: ReferenceType {
         ).try_into().unwrap()
     }
 
-}
+    /// An auto-incrementing integer to uniquely identify a connected Gamepad.
+    ///
+    /// [(JavaScript docs)](https://developer.mozilla.org/en-US/docs/Web/API/Gamepad/index)
+    // https://www.w3.org/TR/gamepad/#dom-gamepad-index
+    #[inline]
+    fn index(&self) -> i32 {
+        js!(
+            return @{self.as_ref()}.index;
+        ).try_into().unwrap()
+    }
 
+    /// Is this gamepad connected to the system, powered on, and usable?
+    ///
+    /// [(JavaScript docs)](https://developer.mozilla.org/en-US/docs/Web/API/Gamepad/connected)
+    // https://www.w3.org/TR/gamepad/#dom-gamepad-connected
+    #[inline]
+    fn connected(&self) -> bool {
+        js!(
+            return @{self.as_ref()}.connected;
+        ).try_into().unwrap()
+    }
+
+    /// Monotonically increasing time this gamepad was updated.
+    ///
+    /// [(JavaScript docs)](https://developer.mozilla.org/en-US/docs/Web/API/Gamepad/timestamp)
+    // https://www.w3.org/TR/gamepad/#dom-gamepad-timestamp
+    #[inline]
+    fn timestamp(&self) -> f64 {
+        js!(
+            return @{self.as_ref()}.timestamp;
+        ).try_into().unwrap()
+    }
+
+    /// The mapping in use for this device.
+    ///
+    /// [(JavaScript docs)](https://developer.mozilla.org/en-US/docs/Web/API/Gamepad/mapping)
+    // https://www.w3.org/TR/gamepad/#dom-gamepad-mapping
+    #[inline]
+    fn mapping(&self) -> GamepadMappingType {
+        js!(
+            return @{self.as_ref()}.mapping;
+        ).try_into().unwrap()
+    }
+
+    /// Array of values for all axes of the gamepad.
+    ///
+    /// [(JavaScript docs)](https://developer.mozilla.org/en-US/docs/Web/API/Gamepad/axes)
+    // https://www.w3.org/TR/gamepad/#dom-gamepad-axes
+    #[inline]
+    fn axes(&self) -> Vec<f64> {
+        js!(
+            return @{self.as_ref()}.axes;
+        ).try_into().unwrap()
+    }
+
+    /// Array of button states for all buttons of the gamepad.
+    ///
+    /// [(JavaScript docs)](https://developer.mozilla.org/en-US/docs/Web/API/Gamepad/buttons)
+    // https://www.w3.org/TR/gamepad/#dom-gamepad-buttons
+    #[inline]
+    fn buttons(&self) -> Vec<GamepadButton> {
+        js!(
+            return @{self.as_ref()}.buttons;
+        ).try_into().unwrap()
+    }
+}
 
 /// A reference to a JavaScript object which implements the [IGamepad](trait.IGamepad.html)
 /// interface.

--- a/src/webapi/gamepad.rs
+++ b/src/webapi/gamepad.rs
@@ -1,5 +1,3 @@
-//use std::fmt::Debug;
-
 use webcore::reference_type::ReferenceType;
 use webcore::try_from::{
     TryFrom,
@@ -57,7 +55,7 @@ pub trait IGamepadButton: ReferenceType {
 
     /// Is the button currently touched?
     ///
-    /// MDN does not document this, it may be unsupported by browsers.
+    /// MDN does not document this. Firefox supports it, but Chrome (as of v65) does not.
     // https://w3c.github.io/gamepad/#dom-gamepadbutton-touched
     #[inline]
     fn touched(&self) -> bool {
@@ -98,7 +96,7 @@ pub trait IGamepad: ReferenceType {
     /// A string containing some information about this gamepad.
     ///
     /// [(JavaScript docs)](https://developer.mozilla.org/en-US/docs/Web/API/Gamepad/id)
-    // https://www.w3.org/TR/gamepad/#dom-gamepad-id
+    // https://w3c.github.io/gamepad/#dom-gamepad-id
     #[inline]
     fn id(&self) -> String {
         js!(
@@ -109,7 +107,7 @@ pub trait IGamepad: ReferenceType {
     /// An auto-incrementing integer to uniquely identify a connected Gamepad.
     ///
     /// [(JavaScript docs)](https://developer.mozilla.org/en-US/docs/Web/API/Gamepad/index)
-    // https://www.w3.org/TR/gamepad/#dom-gamepad-index
+    // https://w3c.github.io/gamepad/#dom-gamepad-index
     #[inline]
     fn index(&self) -> i32 {
         js!(
@@ -120,7 +118,7 @@ pub trait IGamepad: ReferenceType {
     /// Is this gamepad connected to the system, powered on, and usable?
     ///
     /// [(JavaScript docs)](https://developer.mozilla.org/en-US/docs/Web/API/Gamepad/connected)
-    // https://www.w3.org/TR/gamepad/#dom-gamepad-connected
+    // https://w3c.github.io/gamepad/#dom-gamepad-connected
     #[inline]
     fn connected(&self) -> bool {
         js!(
@@ -131,7 +129,7 @@ pub trait IGamepad: ReferenceType {
     /// Monotonically increasing time this gamepad was updated.
     ///
     /// [(JavaScript docs)](https://developer.mozilla.org/en-US/docs/Web/API/Gamepad/timestamp)
-    // https://www.w3.org/TR/gamepad/#dom-gamepad-timestamp
+    // https://w3c.github.io/gamepad/#dom-gamepad-timestamp
     #[inline]
     fn timestamp(&self) -> f64 {
         js!(
@@ -142,7 +140,7 @@ pub trait IGamepad: ReferenceType {
     /// The mapping in use for this device.
     ///
     /// [(JavaScript docs)](https://developer.mozilla.org/en-US/docs/Web/API/Gamepad/mapping)
-    // https://www.w3.org/TR/gamepad/#dom-gamepad-mapping
+    // https://w3c.github.io/gamepad/#dom-gamepad-mapping
     #[inline]
     fn mapping(&self) -> GamepadMappingType {
         js!(
@@ -153,7 +151,7 @@ pub trait IGamepad: ReferenceType {
     /// Array of values for all axes of the gamepad.
     ///
     /// [(JavaScript docs)](https://developer.mozilla.org/en-US/docs/Web/API/Gamepad/axes)
-    // https://www.w3.org/TR/gamepad/#dom-gamepad-axes
+    // https://w3c.github.io/gamepad/#dom-gamepad-axes
     #[inline]
     fn axes(&self) -> Vec<f64> {
         js!(
@@ -164,7 +162,7 @@ pub trait IGamepad: ReferenceType {
     /// Array of button states for all buttons of the gamepad.
     ///
     /// [(JavaScript docs)](https://developer.mozilla.org/en-US/docs/Web/API/Gamepad/buttons)
-    // https://www.w3.org/TR/gamepad/#dom-gamepad-buttons
+    // https://w3c.github.io/gamepad/#dom-gamepad-buttons
     #[inline]
     fn buttons(&self) -> Vec<GamepadButton> {
         js!(
@@ -187,7 +185,7 @@ impl IGamepad for Gamepad {}
 /// Retrieve all connected gamepads, in an array indexed by each gamepad's `index` member.
 ///
 /// [(JavaScript docs)](https://developer.mozilla.org/en-US/docs/Web/API/Navigator/getGamepads)
-// https://www.w3.org/TR/gamepad/#dom-gamepad-axes
+// https://w3c.github.io/gamepad/#dom-gamepad-axes
 pub fn get_gamepads() -> Vec<Option<Gamepad>> {
     js!(
         return Array.from(navigator.getGamepads());

--- a/src/webapi/gamepad.rs
+++ b/src/webapi/gamepad.rs
@@ -168,9 +168,11 @@ impl Gamepad {
 
     /// Retrieve all connected gamepads, in an array indexed by each gamepad's `index` member.
     ///
+    /// Chrome doesn't update Gamepad state automatically, you must call this function each frame.
+    ///
     /// [(JavaScript docs)](https://developer.mozilla.org/en-US/docs/Web/API/Navigator/getGamepads)
     // https://w3c.github.io/gamepad/#dom-navigator-getgamepads
-    pub fn get_gamepads() -> Vec<Option<Gamepad>> {
+    pub fn get_all() -> Vec<Option<Gamepad>> {
         js!(
             return Array.from(navigator.getGamepads());
         ).try_into().unwrap()

--- a/src/webapi/gamepad.rs
+++ b/src/webapi/gamepad.rs
@@ -1,0 +1,48 @@
+//use std::fmt::Debug;
+
+use webcore::reference_type::ReferenceType;
+use webcore::try_from::TryInto;
+use webcore::value::Reference;
+
+/// The set of known gamepad layout mappings.
+///
+/// [(JavaScript docs)](https://developer.mozilla.org/en-US/docs/Web/API/Gamepad/mapping)
+// https://w3c.github.io/gamepad/#dom-gamepadmappingtype
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+pub enum GamepadMappingType {
+    /// No mapping is in use for this gamepad
+    NoMapping,
+    /// This gamepad is mapped to the [Standard Gamepad layout](https://w3c.github.io/gamepad/#remapping)
+    Standard,
+}
+
+/// An individual gamepad/controller.
+///
+/// [(JavaScript docs)](https://developer.mozilla.org/en-US/docs/Web/API/Gamepad)
+// https://w3c.github.io/gamepad/#gamepad-interface
+pub trait IGamepad: ReferenceType {
+
+    /// A string containing some information about this gamepad.
+    ///
+    /// [(JavaScript docs)](https://developer.mozilla.org/en-US/docs/Web/API/Gamepad/id)
+    // https://w3c.github.io/gamepad/#gamepad-interface
+    #[inline]
+    fn id(&self) -> String {
+        js!(
+            return @{self.as_ref()}.id;
+        ).try_into().unwrap()
+    }
+
+}
+
+
+/// A reference to a JavaScript object which implements the [IGamepad](trait.IGamepad.html)
+/// interface.
+///
+/// [(JavaScript docs)](https://developer.mozilla.org/en-US/docs/Web/API/Gamepad)
+// https://w3c.github.io/gamepad/#gamepad-interface
+#[derive(Clone, Debug, Eq, PartialEq, ReferenceType)]
+#[reference(instance_of = "Gamepad")]
+pub struct Gamepad( Reference );
+
+impl IGamepad for Gamepad {}

--- a/src/webapi/gamepad.rs
+++ b/src/webapi/gamepad.rs
@@ -1,4 +1,3 @@
-use webcore::reference_type::ReferenceType;
 use webcore::try_from::{
     TryFrom,
     TryInto,
@@ -40,14 +39,18 @@ impl TryFrom<Value> for GamepadMappingType {
 ///
 /// [(JavaScript docs)](https://developer.mozilla.org/en-US/docs/Web/API/GamepadButton)
 // https://w3c.github.io/gamepad/#gamepadbutton-interface
-pub trait IGamepadButton: ReferenceType {
+#[derive(Clone, Debug, Eq, PartialEq, ReferenceType)]
+#[reference(instance_of = "GamepadButton")]
+pub struct GamepadButton( Reference );
+
+impl GamepadButton {
 
     /// Is the button currently pressed?
     ///
     /// [(JavaScript docs)](https://developer.mozilla.org/en-US/docs/Web/API/GamepadButton/pressed)
     // https://w3c.github.io/gamepad/#dom-gamepadbutton-pressed
     #[inline]
-    fn pressed(&self) -> bool {
+    pub fn pressed(&self) -> bool {
         js!(
             return @{self.as_ref()}.pressed;
         ).try_into().unwrap()
@@ -58,7 +61,7 @@ pub trait IGamepadButton: ReferenceType {
     /// MDN does not document this. Firefox supports it, but Chrome (as of v65) does not.
     // https://w3c.github.io/gamepad/#dom-gamepadbutton-touched
     #[inline]
-    fn touched(&self) -> bool {
+    pub fn touched(&self) -> bool {
         js!(
             return @{self.as_ref()}.touched;
         ).try_into().unwrap()
@@ -69,36 +72,29 @@ pub trait IGamepadButton: ReferenceType {
     /// [(JavaScript docs)](https://developer.mozilla.org/en-US/docs/Web/API/GamepadButton/value)
     // https://w3c.github.io/gamepad/#dom-gamepadbutton-touched
     #[inline]
-    fn value(&self) -> f64 {
+    pub fn value(&self) -> f64 {
         js!(
             return @{self.as_ref()}.value;
         ).try_into().unwrap()
     }
 }
 
-/// A reference to a JavaScript object which implements the [IGamepadButton](trait.IGamepadButton.html)
-/// interface.
-///
-/// [(JavaScript docs)](https://developer.mozilla.org/en-US/docs/Web/API/GamepadButton)
-// https://w3c.github.io/gamepad/#gamepadbutton-interface
-#[derive(Clone, Debug, Eq, PartialEq, ReferenceType)]
-#[reference(instance_of = "GamepadButton")]
-pub struct GamepadButton( Reference );
-
-impl IGamepadButton for GamepadButton {}
-
 /// An individual gamepad/controller.
 ///
 /// [(JavaScript docs)](https://developer.mozilla.org/en-US/docs/Web/API/Gamepad)
 // https://w3c.github.io/gamepad/#gamepad-interface
-pub trait IGamepad: ReferenceType {
+#[derive(Clone, Debug, Eq, PartialEq, ReferenceType)]
+#[reference(instance_of = "Gamepad")]
+pub struct Gamepad( Reference );
+
+impl Gamepad {
 
     /// A string containing some information about this gamepad.
     ///
     /// [(JavaScript docs)](https://developer.mozilla.org/en-US/docs/Web/API/Gamepad/id)
     // https://w3c.github.io/gamepad/#dom-gamepad-id
     #[inline]
-    fn id(&self) -> String {
+    pub fn id(&self) -> String {
         js!(
             return @{self.as_ref()}.id;
         ).try_into().unwrap()
@@ -109,7 +105,7 @@ pub trait IGamepad: ReferenceType {
     /// [(JavaScript docs)](https://developer.mozilla.org/en-US/docs/Web/API/Gamepad/index)
     // https://w3c.github.io/gamepad/#dom-gamepad-index
     #[inline]
-    fn index(&self) -> i32 {
+    pub fn index(&self) -> i32 {
         js!(
             return @{self.as_ref()}.index;
         ).try_into().unwrap()
@@ -120,7 +116,7 @@ pub trait IGamepad: ReferenceType {
     /// [(JavaScript docs)](https://developer.mozilla.org/en-US/docs/Web/API/Gamepad/connected)
     // https://w3c.github.io/gamepad/#dom-gamepad-connected
     #[inline]
-    fn connected(&self) -> bool {
+    pub fn connected(&self) -> bool {
         js!(
             return @{self.as_ref()}.connected;
         ).try_into().unwrap()
@@ -131,7 +127,7 @@ pub trait IGamepad: ReferenceType {
     /// [(JavaScript docs)](https://developer.mozilla.org/en-US/docs/Web/API/Gamepad/timestamp)
     // https://w3c.github.io/gamepad/#dom-gamepad-timestamp
     #[inline]
-    fn timestamp(&self) -> f64 {
+    pub fn timestamp(&self) -> f64 {
         js!(
             return @{self.as_ref()}.timestamp;
         ).try_into().unwrap()
@@ -142,7 +138,7 @@ pub trait IGamepad: ReferenceType {
     /// [(JavaScript docs)](https://developer.mozilla.org/en-US/docs/Web/API/Gamepad/mapping)
     // https://w3c.github.io/gamepad/#dom-gamepad-mapping
     #[inline]
-    fn mapping(&self) -> GamepadMappingType {
+    pub fn mapping(&self) -> GamepadMappingType {
         js!(
             return @{self.as_ref()}.mapping;
         ).try_into().unwrap()
@@ -153,7 +149,7 @@ pub trait IGamepad: ReferenceType {
     /// [(JavaScript docs)](https://developer.mozilla.org/en-US/docs/Web/API/Gamepad/axes)
     // https://w3c.github.io/gamepad/#dom-gamepad-axes
     #[inline]
-    fn axes(&self) -> Vec<f64> {
+    pub fn axes(&self) -> Vec<f64> {
         js!(
             return @{self.as_ref()}.axes;
         ).try_into().unwrap()
@@ -164,32 +160,21 @@ pub trait IGamepad: ReferenceType {
     /// [(JavaScript docs)](https://developer.mozilla.org/en-US/docs/Web/API/Gamepad/buttons)
     // https://w3c.github.io/gamepad/#dom-gamepad-buttons
     #[inline]
-    fn buttons(&self) -> Vec<GamepadButton> {
+    pub fn buttons(&self) -> Vec<GamepadButton> {
         js!(
             return @{self.as_ref()}.buttons;
         ).try_into().unwrap()
     }
-}
 
-/// A reference to a JavaScript object which implements the [IGamepad](trait.IGamepad.html)
-/// interface.
-///
-/// [(JavaScript docs)](https://developer.mozilla.org/en-US/docs/Web/API/Gamepad)
-// https://w3c.github.io/gamepad/#gamepad-interface
-#[derive(Clone, Debug, Eq, PartialEq, ReferenceType)]
-#[reference(instance_of = "Gamepad")]
-pub struct Gamepad( Reference );
-
-impl IGamepad for Gamepad {}
-
-/// Retrieve all connected gamepads, in an array indexed by each gamepad's `index` member.
-///
-/// [(JavaScript docs)](https://developer.mozilla.org/en-US/docs/Web/API/Navigator/getGamepads)
-// https://w3c.github.io/gamepad/#dom-gamepad-axes
-pub fn get_gamepads() -> Vec<Option<Gamepad>> {
-    js!(
-        return Array.from(navigator.getGamepads());
-    ).try_into().unwrap()
+    /// Retrieve all connected gamepads, in an array indexed by each gamepad's `index` member.
+    ///
+    /// [(JavaScript docs)](https://developer.mozilla.org/en-US/docs/Web/API/Navigator/getGamepads)
+    // https://w3c.github.io/gamepad/#dom-navigator-getgamepads
+    pub fn get_gamepads() -> Vec<Option<Gamepad>> {
+        js!(
+            return Array.from(navigator.getGamepads());
+        ).try_into().unwrap()
+    }
 }
 
 #[cfg(test)]

--- a/src/webapi/gamepad.rs
+++ b/src/webapi/gamepad.rs
@@ -183,3 +183,13 @@ pub trait IGamepad: ReferenceType {
 pub struct Gamepad( Reference );
 
 impl IGamepad for Gamepad {}
+
+/// Retrieve all connected gamepads, in an array indexed by each gamepad's `index` member.
+///
+/// [(JavaScript docs)](https://developer.mozilla.org/en-US/docs/Web/API/Navigator/getGamepads)
+// https://www.w3.org/TR/gamepad/#dom-gamepad-axes
+pub fn get_gamepads() -> Vec<Option<Gamepad>> {
+    js!(
+        return Array.from(navigator.getGamepads());
+    ).try_into().unwrap()
+}

--- a/src/webapi/mod.rs
+++ b/src/webapi/mod.rs
@@ -37,3 +37,4 @@ pub mod non_element_parent_node;
 pub mod console;
 pub mod html_collection;
 pub mod child_node;
+pub mod gamepad;


### PR DESCRIPTION
This PR fully wraps the [current Gamepad API spec](https://w3c.github.io/gamepad/).

The [Gamepad API](https://developer.mozilla.org/en-US/docs/Web/API/Gamepad_API) is important for Rust browser games. It is [supported on all major browsers](https://caniuse.com/#feat=gamepad).

`GamepadEvent` and `GamepadButtonMapping` are unit-tested. The rest of the API is not testable, because `Gamepad` and `GamepadButton` are not constructible. 

In lieu of tests, I added a Gamepad example ([deployed here](https://coryshrmn.github.io/stdweb/examples/gamepad/deploy/)). It demonstrates the entire API (except `GamepadButton::touched()`, which is not yet supported in Chrome). I verified the example works perfectly on Firefox, Chrome, and Safari.

Please let me know if there is anything else I can do.
Thanks!