### PR TITLE
Expose FileReaderReadyState as public

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -234,7 +234,7 @@ pub mod web {
     pub use webapi::location::Location;
     pub use webapi::array_buffer::ArrayBuffer;
     pub use webapi::typed_array::TypedArray;
-    pub use webapi::file_reader::{FileReader, FileReaderResult};
+    pub use webapi::file_reader::{FileReader, FileReaderResult, FileReaderReadyState};
     pub use webapi::history::History;
     pub use webapi::web_socket::{WebSocket, SocketCloseCode, SocketBinaryType, SocketReadyState};
     pub use webapi::rendering_context::{RenderingContext, CanvasRenderingContext2d, CanvasGradient, CanvasPattern, CanvasStyle, CompositeOperation, FillRule, ImageData, LineCap, LineJoin, Repetition, TextAlign, TextBaseline, TextMetrics};

--- a/src/webapi/file_reader.rs
+++ b/src/webapi/file_reader.rs
@@ -33,8 +33,11 @@ pub enum FileReaderResult {
 /// [(JavaScript docs)](https://developer.mozilla.org/en-US/docs/Web/API/FileReader/readyState)
 #[derive(Copy, Clone, PartialEq, Eq, Debug)]
 pub enum FileReaderReadyState {
+    /// No data has been loaded yet.
     Empty,
+    /// Data is currently being loaded.
     Loading,
+    /// The entire read request has been completed.
     Done
 }
 


### PR DESCRIPTION
This is mandatory to check the FileReader state after using it.