### PR TITLE
 Add support for the wheel event

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -300,6 +300,8 @@ pub mod web {
             MouseOutEvent,
             MouseEnterEvent,
             MouseLeaveEvent,
+            MouseWheelEvent,
+            MouseWheelDeltaMode,
             MouseButton
         };
 

--- a/src/webapi/events/mouse.rs
+++ b/src/webapi/events/mouse.rs
@@ -447,13 +447,77 @@ impl ConcreteEvent for MouseLeaveEvent {
 #[derive(Clone, Debug, PartialEq, Eq, ReferenceType)]
 #[reference(instance_of = "MouseEvent")] // TODO: Better type check.
 #[reference(subclass_of(Event, UiEvent, MouseEvent))]
-pub struct WheelEvent( Reference );
+pub struct MouseWheelEvent( Reference );
 
-impl IEvent for WheelEvent {}
-impl IUiEvent for WheelEvent {}
-impl IMouseEvent for WheelEvent {}
-impl ConcreteEvent for WheelEvent {
+impl IEvent for MouseWheelEvent {}
+impl IUiEvent for MouseWheelEvent {}
+impl IMouseEvent for MouseWheelEvent {}
+impl ConcreteEvent for MouseWheelEvent {
     const EVENT_TYPE: &'static str = "mouseleave";
+}
+
+impl MouseWheelEvent {
+    /// The change in X of the wheel
+    ///
+    /// [(Javascript docs)](https://developer.mozilla.org/en-US/docs/Web/API/WheelEvent/deltaX)
+    // https://w3c.github.io/uievents/#dom-wheelevent-deltax
+    pub fn delta_x(&mut self) -> f64 {
+        js! (
+            @{&self.0}.deltaX
+        ).try_into().unwrap()
+    }
+
+    /// The change in Y of the wheel
+    ///
+    /// [(Javascript docs)](https://developer.mozilla.org/en-US/docs/Web/API/WheelEvent/deltaY)
+    // https://w3c.github.io/uievents/#dom-wheelevent-deltay
+    pub fn delta_y(&mut self) -> f64 {
+        js! (
+            @{&self.0}.deltaY
+        ).try_into().unwrap()
+    }
+
+    /// The change in Z of the wheel
+    ///
+    /// [(Javascript docs)](https://developer.mozilla.org/en-US/docs/Web/API/WheelEvent/deltaZ)
+    // https://w3c.github.io/uievents/#dom-wheelevent-deltaz
+    pub fn delta_z(&mut self) -> f64 {
+        js! (
+            @{&self.0}.deltaZ
+        ).try_into().unwrap()
+    }
+
+    /// The unit of measure of change
+    ///
+    /// [(JavaScript docs)](https://developer.mozilla.org/en-US/docs/Web/API/WheelEvent/deltaMode)
+    // https://w3c.github.io/uievents/#dom-wheelevent-deltamode
+    pub fn delta_mode(&mut self) -> MouseWheelDeltaMode {
+        let mode: u64 = js! (
+            @{&self.0}.deltaMode
+        ).try_into().unwrap();
+        match mode {
+            0 => MouseWheelDeltaMode::DomDeltaPixel,
+            1 => MouseWheelDeltaMode::DomDeltaLine,
+            2 => MouseWheelDeltaMode::DomDeltaPage,
+            _ => unreachable!()
+        }
+    }
+}
+
+/// What unit of measure the mouse wheel delta is in
+///
+/// [(JavaScipt docs)](https://developer.mozilla.org/en-US/docs/Web/API/WheelEvent/deltaMode)
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum MouseWheelDeltaMode {
+    /// The unit of measurement for the delta is pixels
+    // https://w3c.github.io/uievents/#dom-wheelevent-dom_delta_pixel
+    DomDeltaPixel = 0,
+     /// The unit of measurement for the delta is lines
+    // https://w3c.github.io/uievents/#dom-wheelevent-dom_delta_line
+    DomDeltaLine = 1,
+     /// The unit of measurement for the delta is pages
+    // https://w3c.github.io/uievents/#dom-wheelevent-dom_delta_page
+    DomDeltaPage = 2
 }
 
 #[cfg(all(test, feature = "web_test"))]
@@ -593,11 +657,11 @@ mod tests {
     }
 
     #[test]
-    fn test_mouse_leave_event() {
-        let event: WheelEvent = js!(
-            return new MouseEvent( @{WheelEvent::EVENT_TYPE} );
+    fn test_mouse_wheel_event() {
+        let event: MouseWheelEvent = js!(
+            return new MouseEvent( @{MouseWheelEvent::EVENT_TYPE} );
         ).try_into()
             .unwrap();
-        assert_eq!( event.event_type(), WheelEvent::EVENT_TYPE );
+        assert_eq!( event.event_type(), MouseWheelEvent::EVENT_TYPE );
     }
 }

--- a/src/webapi/events/mouse.rs
+++ b/src/webapi/events/mouse.rs
@@ -439,7 +439,7 @@ impl ConcreteEvent for MouseLeaveEvent {
     const EVENT_TYPE: &'static str = "mouseleave";
 }
 
-/// The `WheelEvent` is fired when a pointing device's wheel button (usually a mousewheel)
+/// The `MouseWheelEvent` is fired when a pointing device's wheel button (usually a mousewheel)
 /// is rotated over the element that has the listener attached.
 ///
 /// [(JavaScript docs)](https://developer.mozilla.org/en-US/docs/Web/Events/wheel)
@@ -461,9 +461,9 @@ impl MouseWheelEvent {
     ///
     /// [(Javascript docs)](https://developer.mozilla.org/en-US/docs/Web/API/WheelEvent/deltaX)
     // https://w3c.github.io/uievents/#dom-wheelevent-deltax
-    pub fn delta_x(&mut self) -> f64 {
+    pub fn delta_x(&self) -> f64 {
         js! (
-            @{&self.0}.deltaX
+            return @{self}.deltaX;
         ).try_into().unwrap()
     }
 
@@ -471,9 +471,9 @@ impl MouseWheelEvent {
     ///
     /// [(Javascript docs)](https://developer.mozilla.org/en-US/docs/Web/API/WheelEvent/deltaY)
     // https://w3c.github.io/uievents/#dom-wheelevent-deltay
-    pub fn delta_y(&mut self) -> f64 {
+    pub fn delta_y(&self) -> f64 {
         js! (
-            @{&self.0}.deltaY
+            return @{self}.deltaY;
         ).try_into().unwrap()
     }
 
@@ -481,9 +481,9 @@ impl MouseWheelEvent {
     ///
     /// [(Javascript docs)](https://developer.mozilla.org/en-US/docs/Web/API/WheelEvent/deltaZ)
     // https://w3c.github.io/uievents/#dom-wheelevent-deltaz
-    pub fn delta_z(&mut self) -> f64 {
+    pub fn delta_z(&self) -> f64 {
         js! (
-            @{&self.0}.deltaZ
+            return @{self}.deltaZ;
         ).try_into().unwrap()
     }
 
@@ -491,14 +491,14 @@ impl MouseWheelEvent {
     ///
     /// [(JavaScript docs)](https://developer.mozilla.org/en-US/docs/Web/API/WheelEvent/deltaMode)
     // https://w3c.github.io/uievents/#dom-wheelevent-deltamode
-    pub fn delta_mode(&mut self) -> MouseWheelDeltaMode {
-        let mode: u64 = js! (
+    pub fn delta_mode(&self) -> MouseWheelDeltaMode {
+        let mode: u32 = js! (
             @{&self.0}.deltaMode
         ).try_into().unwrap();
         match mode {
-            0 => MouseWheelDeltaMode::DomDeltaPixel,
-            1 => MouseWheelDeltaMode::DomDeltaLine,
-            2 => MouseWheelDeltaMode::DomDeltaPage,
+            0 => MouseWheelDeltaMode::Pixel,
+            1 => MouseWheelDeltaMode::Line,
+            2 => MouseWheelDeltaMode::Page,
             _ => unreachable!()
         }
     }
@@ -511,13 +511,13 @@ impl MouseWheelEvent {
 pub enum MouseWheelDeltaMode {
     /// The unit of measurement for the delta is pixels
     // https://w3c.github.io/uievents/#dom-wheelevent-dom_delta_pixel
-    DomDeltaPixel = 0,
-     /// The unit of measurement for the delta is lines
+    Pixel,
+    /// The unit of measurement for the delta is lines
     // https://w3c.github.io/uievents/#dom-wheelevent-dom_delta_line
-    DomDeltaLine = 1,
+    Line,
      /// The unit of measurement for the delta is pages
     // https://w3c.github.io/uievents/#dom-wheelevent-dom_delta_page
-    DomDeltaPage = 2
+    Page
 }
 
 #[cfg(all(test, feature = "web_test"))]

--- a/src/webapi/events/mouse.rs
+++ b/src/webapi/events/mouse.rs
@@ -493,7 +493,7 @@ impl MouseWheelEvent {
     // https://w3c.github.io/uievents/#dom-wheelevent-deltamode
     pub fn delta_mode(&self) -> MouseWheelDeltaMode {
         let mode: u32 = js! (
-            @{&self.0}.deltaMode
+            return @{self}.deltaMode;
         ).try_into().unwrap();
         match mode {
             0 => MouseWheelDeltaMode::Pixel,

--- a/src/webapi/events/mouse.rs
+++ b/src/webapi/events/mouse.rs
@@ -439,6 +439,23 @@ impl ConcreteEvent for MouseLeaveEvent {
     const EVENT_TYPE: &'static str = "mouseleave";
 }
 
+/// The `WheelEvent` is fired when a pointing device's wheel button (usually a mousewheel)
+/// is rotated over the element that has the listener attached.
+///
+/// [(JavaScript docs)](https://developer.mozilla.org/en-US/docs/Web/Events/mousewheel)
+// https://w3c.github.io/uievents/#event-type-wheel
+#[derive(Clone, Debug, PartialEq, Eq, ReferenceType)]
+#[reference(instance_of = "MouseEvent")] // TODO: Better type check.
+#[reference(subclass_of(Event, UiEvent, MouseEvent))]
+pub struct WheelEvent( Reference );
+
+impl IEvent for WheelEvent {}
+impl IUiEvent for WheelEvent {}
+impl IMouseEvent for WheelEvent {}
+impl ConcreteEvent for WheelEvent {
+    const EVENT_TYPE: &'static str = "mouseleave";
+}
+
 #[cfg(all(test, feature = "web_test"))]
 mod tests {
     use super::*;
@@ -573,5 +590,14 @@ mod tests {
         ).try_into()
             .unwrap();
         assert_eq!( event.event_type(), MouseLeaveEvent::EVENT_TYPE );
+    }
+
+    #[test]
+    fn test_mouse_leave_event() {
+        let event: WheelEvent = js!(
+            return new MouseEvent( @{WheelEvent::EVENT_TYPE} );
+        ).try_into()
+            .unwrap();
+        assert_eq!( event.event_type(), WheelEvent::EVENT_TYPE );
     }
 }

--- a/src/webapi/events/mouse.rs
+++ b/src/webapi/events/mouse.rs
@@ -442,7 +442,7 @@ impl ConcreteEvent for MouseLeaveEvent {
 /// The `WheelEvent` is fired when a pointing device's wheel button (usually a mousewheel)
 /// is rotated over the element that has the listener attached.
 ///
-/// [(JavaScript docs)](https://developer.mozilla.org/en-US/docs/Web/Events/mousewheel)
+/// [(JavaScript docs)](https://developer.mozilla.org/en-US/docs/Web/Events/wheel)
 // https://w3c.github.io/uievents/#event-type-wheel
 #[derive(Clone, Debug, PartialEq, Eq, ReferenceType)]
 #[reference(instance_of = "MouseEvent")] // TODO: Better type check.
@@ -453,7 +453,7 @@ impl IEvent for MouseWheelEvent {}
 impl IUiEvent for MouseWheelEvent {}
 impl IMouseEvent for MouseWheelEvent {}
 impl ConcreteEvent for MouseWheelEvent {
-    const EVENT_TYPE: &'static str = "mouseleave";
+    const EVENT_TYPE: &'static str = "wheel";
 }
 
 impl MouseWheelEvent {


### PR DESCRIPTION
So the `wheel` event is a special event that inherits from `MouseEvent.` I have two main questions: 

- Should I impl the `wheel` properties directly on the event, or make a trait? AFAIK only one event is a "Wheel Event" so I don't think a trait is necessary. 

- Should the event be named `WheelEvent` or `MouseWheelEvent`? `WheelEvent` is more in keeping with the DOM api name, but `MouseWheelEvent` has greater consistency with the rest of the module.

Resolves #230 