### PR TITLE
Add insertAdjacentHTML binding and helpers.

### DIFF
--- a/src/webapi/dom_exception.rs
+++ b/src/webapi/dom_exception.rs
@@ -44,6 +44,17 @@ impl IDomException for InvalidAccessError {}
 
 error_boilerplate! { InvalidAccessError, name = "InvalidAccessError" }
 
+/// Occurs when the object can not be modified.
+// NoModificationAllowedError
+#[derive(Clone, Debug, PartialEq, Eq, ReferenceType)]
+#[reference(subclass_of(Error, DomException))]
+pub struct NoModificationAllowedError( Reference );
+
+impl IError for NoModificationAllowedError {}
+impl IDomException for NoModificationAllowedError {}
+
+error_boilerplate! { NoModificationAllowedError, name = "NoModificationAllowedError" }
+
 /// Occurs when the specified object cannot be found.
 // https://heycam.github.io/webidl/#notfounderror
 #[derive(Clone, Debug, PartialEq, Eq, ReferenceType)]

--- a/src/webapi/dom_exception.rs
+++ b/src/webapi/dom_exception.rs
@@ -45,7 +45,7 @@ impl IDomException for InvalidAccessError {}
 error_boilerplate! { InvalidAccessError, name = "InvalidAccessError" }
 
 /// Occurs when the object can not be modified.
-// NoModificationAllowedError
+// https://heycam.github.io/webidl/#nomodificationallowederror
 #[derive(Clone, Debug, PartialEq, Eq, ReferenceType)]
 #[reference(subclass_of(Error, DomException))]
 pub struct NoModificationAllowedError( Reference );

--- a/src/webapi/element.rs
+++ b/src/webapi/element.rs
@@ -168,10 +168,10 @@ pub trait IElement: INode + IParentNode + IChildNode {
     /// Insert nodes from HTML fragment into specified position.
     ///
     /// [(JavaScript docs)](https://developer.mozilla.org/en-US/docs/Web/API/Element/insertAdjacentHTML)
-    // https://dom.spec.whatwg.org/#dom-element-insertadjacentelement
+    // https://dom.spec.whatwg.org/#ref-for-dom-element-insertadjacentelement
     fn insert_adjacent_html( &self, position: &InsertPosition, html: &str ) -> Result<(), InsertAdjacentError> {
         js_try!( @(no_return)
-            @{self.as_ref()}.insertAdjacentHTML( @{position.keyword()}, @{html} );
+            @{self.as_ref()}.insertAdjacentHTML( @{position.as_str()}, @{html} );
         ).unwrap()
     }
 
@@ -242,14 +242,14 @@ error_enum_boilerplate! {
 }
 
 impl InsertPosition {
-	fn keyword(&self) -> &str {
-		match *self {
-			InsertPosition::BeforeBegin => "beforebegin",
-			InsertPosition::AfterBegin => "afterbegin",
-			InsertPosition::BeforeEnd => "beforeend",
-			InsertPosition::AfterEnd => "afterend",
-		}
-	}
+    fn as_str(&self) -> &str {
+        match *self {
+            InsertPosition::BeforeBegin => "beforebegin",
+            InsertPosition::AfterBegin => "afterbegin",
+            InsertPosition::BeforeEnd => "beforeend",
+            InsertPosition::AfterEnd => "afterend",
+        }
+    }
 }
 
 #[cfg(all(test, feature = "web_test"))]

--- a/src/webapi/element.rs
+++ b/src/webapi/element.rs
@@ -178,28 +178,28 @@ pub trait IElement: INode + IParentNode + IChildNode {
     /// Insert nodes from HTML fragment before element.
     ///
     /// [(JavaScript docs)](https://developer.mozilla.org/en-US/docs/Web/API/Element/insertAdjacentHTML)
-    fn insert_html_before_begin( &self, html: &str ) -> Result<(), InsertAdjacentError> {
+    fn insert_html_before( &self, html: &str ) -> Result<(), InsertAdjacentError> {
         self.insert_adjacent_html(InsertPosition::BeforeBegin, html)
     }
 
     /// Insert nodes from HTML fragment as the first children of the element.
     ///
     /// [(JavaScript docs)](https://developer.mozilla.org/en-US/docs/Web/API/Element/insertAdjacentHTML)
-    fn insert_html_after_begin( &self, html: &str ) -> Result<(), InsertAdjacentError> {
+    fn prepend_html( &self, html: &str ) -> Result<(), InsertAdjacentError> {
         self.insert_adjacent_html(InsertPosition::AfterBegin, html)
     }
 
     /// Insert nodes from HTML fragment as the last children of the element.
     ///
     /// [(JavaScript docs)](https://developer.mozilla.org/en-US/docs/Web/API/Element/insertAdjacentHTML)
-    fn insert_html_before_end( &self, html: &str ) -> Result<(), InsertAdjacentError> {
+    fn append_html( &self, html: &str ) -> Result<(), InsertAdjacentError> {
         self.insert_adjacent_html(InsertPosition::BeforeEnd, html)
     }
 
     /// Insert nodes from HTML fragment after element.
     ///
     /// [(JavaScript docs)](https://developer.mozilla.org/en-US/docs/Web/API/Element/insertAdjacentHTML)
-    fn insert_html_after_end( &self, html: &str ) -> Result<(), InsertAdjacentError> {
+    fn insert_html_after( &self, html: &str ) -> Result<(), InsertAdjacentError> {
         self.insert_adjacent_html(InsertPosition::AfterEnd, html)
     }
 }
@@ -264,10 +264,10 @@ mod tests {
         child.set_text_content("child");
         root.append_child(&child);
 
-        child.insert_html_before_begin(" <button>before begin</button> foo ").unwrap();
-        child.insert_html_after_begin("<i>afterbegin").unwrap();
-        child.insert_html_before_end("<h1> Before end</h1>").unwrap();
-        child.insert_html_after_end("after end ").unwrap();
+        child.insert_html_before(" <button>before begin</button> foo ").unwrap();
+        child.prepend_html("<i>afterbegin").unwrap();
+        child.append_html("<h1> Before end</h1>").unwrap();
+        child.insert_html_after("after end ").unwrap();
 
         let html = js!(return @{root}.innerHTML);
         assert_eq!(html, " <button>before begin</button> foo <span><i>afterbegin</i>child<h1> Before end</h1></span>after end ");
@@ -276,7 +276,7 @@ mod tests {
     #[test]
     fn insert_adjacent_html_empty() {
         let root = document().create_element("div").unwrap();
-        root.insert_html_after_begin("").unwrap();
+        root.append_html("").unwrap();
 
         let html = js!(return @{root}.innerHTML);
         assert_eq!(html, "");
@@ -285,7 +285,7 @@ mod tests {
     #[test]
     fn insert_adjacent_html_not_modifiable() {
         let doc = document().document_element().unwrap();
-        assert!(match doc.insert_html_before_begin("foobar").unwrap_err() {
+        assert!(match doc.insert_html_before("foobar").unwrap_err() {
             InsertAdjacentError::NoModificationAllowedError(_) => true,
             _ => false,
         });

--- a/src/webapi/element.rs
+++ b/src/webapi/element.rs
@@ -169,7 +169,7 @@ pub trait IElement: INode + IParentNode + IChildNode {
     ///
     /// [(JavaScript docs)](https://developer.mozilla.org/en-US/docs/Web/API/Element/insertAdjacentHTML)
     // https://dom.spec.whatwg.org/#ref-for-dom-element-insertadjacentelement
-    fn insert_adjacent_html( &self, position: &InsertPosition, html: &str ) -> Result<(), InsertAdjacentError> {
+    fn insert_adjacent_html( &self, position: InsertPosition, html: &str ) -> Result<(), InsertAdjacentError> {
         js_try!( @(no_return)
             @{self.as_ref()}.insertAdjacentHTML( @{position.as_str()}, @{html} );
         ).unwrap()
@@ -179,28 +179,28 @@ pub trait IElement: INode + IParentNode + IChildNode {
     ///
     /// [(JavaScript docs)](https://developer.mozilla.org/en-US/docs/Web/API/Element/insertAdjacentHTML)
     fn insert_html_before_begin( &self, html: &str ) -> Result<(), InsertAdjacentError> {
-        self.insert_adjacent_html(&InsertPosition::BeforeBegin, html)
+        self.insert_adjacent_html(InsertPosition::BeforeBegin, html)
     }
 
     /// Insert nodes from HTML fragment as the first children of the element.
     ///
     /// [(JavaScript docs)](https://developer.mozilla.org/en-US/docs/Web/API/Element/insertAdjacentHTML)
     fn insert_html_after_begin( &self, html: &str ) -> Result<(), InsertAdjacentError> {
-        self.insert_adjacent_html(&InsertPosition::AfterBegin, html)
+        self.insert_adjacent_html(InsertPosition::AfterBegin, html)
     }
 
     /// Insert nodes from HTML fragment as the last children of the element.
     ///
     /// [(JavaScript docs)](https://developer.mozilla.org/en-US/docs/Web/API/Element/insertAdjacentHTML)
     fn insert_html_before_end( &self, html: &str ) -> Result<(), InsertAdjacentError> {
-        self.insert_adjacent_html(&InsertPosition::BeforeEnd, html)
+        self.insert_adjacent_html(InsertPosition::BeforeEnd, html)
     }
 
     /// Insert nodes from HTML fragment after element.
     ///
     /// [(JavaScript docs)](https://developer.mozilla.org/en-US/docs/Web/API/Element/insertAdjacentHTML)
     fn insert_html_after_end( &self, html: &str ) -> Result<(), InsertAdjacentError> {
-        self.insert_adjacent_html(&InsertPosition::AfterEnd, html)
+        self.insert_adjacent_html(InsertPosition::AfterEnd, html)
     }
 }
 


### PR DESCRIPTION
This function provides an efficient way to add nodes to the DOM. This
provides a binding to the raw function as well as helper functions which
make it easier to provide a correct `position` argument.