### PR TITLE
Add createElementNS support

### DIFF
--- a/src/webapi/document.rs
+++ b/src/webapi/document.rs
@@ -22,11 +22,6 @@ use webapi::dom_exception::{InvalidCharacterError, NamespaceError};
 pub struct Document( Reference );
 
 error_enum_boilerplate! {
-    CreateElementError,
-    InvalidCharacterError
-}
-
-error_enum_boilerplate! {
     CreateElementNsError,
     InvalidCharacterError,
     NamespaceError
@@ -63,7 +58,7 @@ impl Document {
     ///
     /// [(JavaScript docs)](https://developer.mozilla.org/en-US/docs/Web/API/Document/createElement)
     // https://dom.spec.whatwg.org/#ref-for-dom-document-createelement
-    pub fn create_element( &self, tag: &str ) -> Result< Element, CreateElementError > {
+    pub fn create_element( &self, tag: &str ) -> Result< Element, InvalidCharacterError > {
         js_try!( return @{self}.createElement( @{tag} ); ).unwrap()
     }
 
@@ -196,7 +191,7 @@ mod web_tests {
     #[test]
     fn test_create_element_invalid_character() {
         match document().create_element("-invalid tag") {
-            Err(CreateElementError::InvalidCharacterError(_)) => (),
+            Err(InvalidCharacterError{..}) => (),
             v => panic!("expected InvalidCharacterError, got {:?}", v),
         }
     }

--- a/src/webapi/document.rs
+++ b/src/webapi/document.rs
@@ -58,6 +58,19 @@ impl Document {
         }
     }
 
+    /// Creates an element with the specified namespace URI and qualified name.
+    /// To create an element without specifying a namespace URI, use the `createElement` method.
+    ///
+    /// [(JavaScript docs)](https://developer.mozilla.org/en-US/docs/Web/API/Document/createElementNS)
+    // https://dom.spec.whatwg.org/#ref-for-dom-document-createelementns
+    pub fn create_element_ns( &self, namespace_uri: &str, tag: &str ) -> Result< Element, TODO > {
+        unsafe {
+            Ok( js!(
+                return @{self}.createElementNS( @{namespace_uri}, @{tag} );
+            ).into_reference_unchecked().unwrap() )
+        }
+    }
+
     /// Creates a new text node.
     ///
     /// [(JavaScript docs)](https://developer.mozilla.org/en-US/docs/Web/API/Document/createTextNode)

--- a/src/webapi/dom_exception.rs
+++ b/src/webapi/dom_exception.rs
@@ -154,6 +154,17 @@ impl IDomException for AbortError {}
 
 error_boilerplate! { AbortError, name = "AbortError" }
 
+/// Indicates an xml namespace-related feature was used incorrectly.
+// https://heycam.github.io/webidl/#namespaceerror
+#[derive(Clone, Debug, ReferenceType)]
+#[reference(subclass_of(Error, DomException))]
+pub struct NamespaceError( Reference );
+
+impl IError for NamespaceError {}
+impl IDomException for NamespaceError {}
+
+error_boilerplate! { NamespaceError, name = "NamespaceError" }
+
 #[cfg(all(test, feature = "web_test"))]
 mod test {
     use super::*;


### PR DESCRIPTION
Add bindings for createElementNS. This is necessary if we would like to use elements other than those in the default namespace, such as the SVG elements.