### PR TITLE
Basic fix for #273, simply forbidding `FnMut`s in `js!`

### DIFF
--- a/src/webapi/event_target.rs
+++ b/src/webapi/event_target.rs
@@ -46,7 +46,7 @@ pub trait IEventTarget: ReferenceType {
     /// [(JavaScript docs)](https://developer.mozilla.org/en-US/docs/Web/API/EventTarget/addEventListener)
     // https://dom.spec.whatwg.org/#ref-for-dom-eventtarget-addeventlistener%E2%91%A0
     fn add_event_listener< T, F >( &self, listener: F ) -> EventListenerHandle
-        where T: ConcreteEvent, F: FnMut( T ) + 'static
+        where T: ConcreteEvent, F: Fn( T ) + 'static
     {
         let reference = self.as_ref();
 

--- a/src/webapi/mutation_observer.rs
+++ b/src/webapi/mutation_observer.rs
@@ -63,7 +63,7 @@ impl MutationObserver {
     /// [(JavaScript docs)](https://developer.mozilla.org/en-US/docs/Web/API/MutationObserver#Constructor)
     // https://dom.spec.whatwg.org/#ref-for-dom-mutationobserver-mutationobserver
     pub fn new< F >( callback: F ) -> MutationObserverHandle
-        where F: FnMut( Vec< MutationRecord >, Self ) + 'static {
+        where F: Fn( Vec< MutationRecord >, Self ) + 'static {
         let callback_reference: Reference = js! ( return @{callback}; ).try_into().unwrap();
 
         MutationObserverHandle {

--- a/src/webcore/serialization.rs
+++ b/src/webcore/serialization.rs
@@ -6,7 +6,7 @@ use std::marker::PhantomData;
 use std::hash::Hash;
 
 use webcore::ffi;
-use webcore::callfn::{CallOnce, CallMut};
+use webcore::callfn::{CallOnce, Call};
 use webcore::newtype::Newtype;
 use webcore::try_from::{TryFrom, TryInto};
 use webcore::number::Number;
@@ -759,7 +759,7 @@ trait FuncallAdapter< F > {
 macro_rules! impl_for_fn {
     ($next:tt => $($kind:ident),*) => {
         impl< $($kind: TryFrom< Value >,)* F > FuncallAdapter< F > for Newtype< (FunctionTag, ($($kind,)*)), F >
-            where F: CallMut< ($($kind,)*) > + 'static, F::Output: JsSerializeOwned
+            where F: Call< ($($kind,)*) > + 'static, F::Output: JsSerializeOwned
         {
             #[allow(unused_mut, unused_variables, non_snake_case)]
             extern fn funcall_adapter(
@@ -897,7 +897,7 @@ macro_rules! impl_for_fn {
         }
 
         impl< $($kind: TryFrom< Value >,)* F > JsSerializeOwned for Newtype< (FunctionTag, ($($kind,)*)), F >
-            where F: CallMut< ($($kind,)*) > + 'static, F::Output: JsSerializeOwned
+            where F: Call< ($($kind,)*) > + 'static, F::Output: JsSerializeOwned
         {
             #[inline]
             fn into_js_owned< 'a >( value: &'a mut Option< Self > ) -> SerializedValue< 'a > {
@@ -913,7 +913,7 @@ macro_rules! impl_for_fn {
         }
 
         impl< $($kind: TryFrom< Value >,)* F > JsSerializeOwned for Newtype< (FunctionTag, ($($kind,)*)), Option< F > >
-            where F: CallMut< ($($kind,)*) > + 'static, F::Output: JsSerializeOwned
+            where F: Call< ($($kind,)*) > + 'static, F::Output: JsSerializeOwned
         {
             #[inline]
             fn into_js_owned< 'a >( value: &'a mut Option< Self > ) -> SerializedValue< 'a > {


### PR DESCRIPTION
This change simply forbids `FnMut`s from being used in `js!` macros, without implementing any `Mut` modifier or any other solution that would allow `FnMut`s to be used in the `js!` macro safely.

**This change is NOT backwards compatible**, but any fixes to #273 will have to break backwards compatibility in some way.

Most notably, MutationObserver::new and IEventTarget::add_event_listener accepted FnMut+'static closures as arguments. I changed these to accept only Fn+'static closures, as handling FnMuts correctly incurs unnecessary overhead for very little benefit (due to the 'static bound), as discussed in #273.

I'll wait on your opinion on whether you think a Mut modifier is worth it or not (and what should happen if illegal recursion is detected, a JavaScript exception or a Rust error) before trying to implement that.