### PR TITLE
Add Mut modifier

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -182,6 +182,7 @@ pub use webcore::array::Array;
 pub use webcore::symbol::Symbol;
 
 pub use webcore::unsafe_typed_array::UnsafeTypedArray;
+pub use webcore::mutfn::Mut;
 pub use webcore::once::Once;
 pub use webcore::instance_of::InstanceOf;
 pub use webcore::reference_type::ReferenceType;

--- a/src/webapi/event_target.rs
+++ b/src/webapi/event_target.rs
@@ -3,6 +3,7 @@ use std::fmt;
 use webcore::value::Reference;
 use webcore::try_from::TryInto;
 use webcore::reference_type::ReferenceType;
+use webcore::mutfn::Mut;
 use webapi::event::{ConcreteEvent, IEvent};
 use private::TODO;
 
@@ -46,12 +47,12 @@ pub trait IEventTarget: ReferenceType {
     /// [(JavaScript docs)](https://developer.mozilla.org/en-US/docs/Web/API/EventTarget/addEventListener)
     // https://dom.spec.whatwg.org/#ref-for-dom-eventtarget-addeventlistener%E2%91%A0
     fn add_event_listener< T, F >( &self, listener: F ) -> EventListenerHandle
-        where T: ConcreteEvent, F: Fn( T ) + 'static
+        where T: ConcreteEvent, F: FnMut( T ) + 'static
     {
         let reference = self.as_ref();
 
         let listener_reference = js! {
-            var listener = @{listener};
+            var listener = @{Mut(listener)};
             @{reference}.addEventListener( @{T::EVENT_TYPE}, listener );
             return listener;
         }.try_into().unwrap();

--- a/src/webapi/event_target.rs
+++ b/src/webapi/event_target.rs
@@ -46,7 +46,7 @@ pub trait IEventTarget: ReferenceType {
     /// [(JavaScript docs)](https://developer.mozilla.org/en-US/docs/Web/API/EventTarget/addEventListener)
     // https://dom.spec.whatwg.org/#ref-for-dom-eventtarget-addeventlistener%E2%91%A0
     fn add_event_listener< T, F >( &self, listener: F ) -> EventListenerHandle
-        where T: ConcreteEvent, F: FnMut( T ) + 'static
+        where T: ConcreteEvent, F: Fn( T ) + 'static
     {
         let reference = self.as_ref();
 

--- a/src/webapi/mutation_observer.rs
+++ b/src/webapi/mutation_observer.rs
@@ -63,7 +63,7 @@ impl MutationObserver {
     /// [(JavaScript docs)](https://developer.mozilla.org/en-US/docs/Web/API/MutationObserver#Constructor)
     // https://dom.spec.whatwg.org/#ref-for-dom-mutationobserver-mutationobserver
     pub fn new< F >( callback: F ) -> MutationObserverHandle
-        where F: FnMut( Vec< MutationRecord >, Self ) + 'static {
+        where F: Fn( Vec< MutationRecord >, Self ) + 'static {
         let callback_reference: Reference = js! ( return @{callback}; ).try_into().unwrap();
 
         MutationObserverHandle {

--- a/src/webapi/mutation_observer.rs
+++ b/src/webapi/mutation_observer.rs
@@ -1,5 +1,6 @@
 use std;
 use webcore::value::{Reference, Value, ConversionError};
+use webcore::mutfn::Mut;
 use webapi::node_list::NodeList;
 use webcore::try_from::{TryFrom, TryInto};
 use webapi::node::{INode, Node};
@@ -63,8 +64,8 @@ impl MutationObserver {
     /// [(JavaScript docs)](https://developer.mozilla.org/en-US/docs/Web/API/MutationObserver#Constructor)
     // https://dom.spec.whatwg.org/#ref-for-dom-mutationobserver-mutationobserver
     pub fn new< F >( callback: F ) -> MutationObserverHandle
-        where F: Fn( Vec< MutationRecord >, Self ) + 'static {
-        let callback_reference: Reference = js! ( return @{callback}; ).try_into().unwrap();
+        where F: FnMut( Vec< MutationRecord >, Self ) + 'static {
+        let callback_reference: Reference = js! ( return @{Mut(callback)}; ).try_into().unwrap();
 
         MutationObserverHandle {
             callback_reference: callback_reference.clone(),

--- a/src/webcore/mod.rs
+++ b/src/webcore/mod.rs
@@ -13,6 +13,7 @@ pub mod array;
 pub mod symbol;
 pub mod type_name;
 pub mod unsafe_typed_array;
+pub mod mutfn;
 pub mod once;
 pub mod instance_of;
 pub mod reference_type;

--- a/src/webcore/mutfn.rs
+++ b/src/webcore/mutfn.rs
@@ -1,0 +1,32 @@
+use std::fmt;
+
+/// A wrapper for passing `FnMut` callbacks into the `js!` macro.
+/// 
+/// Just like when passing regular `Fn` callbacks, don't forget
+/// to `drop()` them on the JavaScript side or else the closure
+/// will be leaked.
+///
+/// # Examples
+///
+/// ```rust
+/// let mut count = 0;
+/// let callback = move || {
+///     count += 1;
+///     println!( "Callback called {} times", count );
+/// };
+/// js! {
+///     var cb = @{Mut(callback)};
+///     cb();
+///     cb();
+///     cb();
+///     cb.drop();
+/// }
+/// ```
+pub struct Mut< T >( pub T );
+
+impl< T > fmt::Debug for Mut< T > {
+    #[inline]
+    fn fmt( &self, formatter: &mut fmt::Formatter ) -> Result< (), fmt::Error > {
+        write!( formatter, "Mut" )
+    }
+}

--- a/src/webcore/serialization.rs
+++ b/src/webcore/serialization.rs
@@ -756,18 +756,24 @@ trait FuncallAdapter< F > {
     extern fn deallocator( callback: *mut F );
 }
 
-macro_rules! impl_for_fn {
-    ($next:tt => $($kind:ident),*) => {
-        impl< $($kind: TryFrom< Value >,)* F > FuncallAdapter< F > for Newtype< (FunctionTag, ($($kind,)*)), F >
-            where F: Call< ($($kind,)*) > + 'static, F::Output: JsSerializeOwned
+macro_rules! impl_for_fn_and_modifier {
+    (
+        args: ($($kind:ident),*),
+        trait: $trait:ident,
+        wrapped type: $wrappedtype:ty,
+        unwrap: $wrapped:ident => $unwrap:expr,
+        serialized to: $serialized_to:tt,
+        call: $callback:ident => $call:expr
+    ) => {
+        impl< $($kind: TryFrom< Value >,)* F > FuncallAdapter< F > for Newtype< (FunctionTag, ($($kind,)*)), $wrappedtype >
+            where F: $trait< ($($kind,)*) > + 'static, F::Output: JsSerializeOwned
         {
             #[allow(unused_mut, unused_variables, non_snake_case)]
             extern fn funcall_adapter(
-                    callback: *mut F,
+                    $callback: *mut F,
                     raw_arguments: *mut SerializedUntaggedArray
                 )
             {
-                let callback = unsafe { &mut *callback };
                 let mut arguments = unsafe { &*raw_arguments }.deserialize();
 
                 unsafe {
@@ -798,7 +804,7 @@ macro_rules! impl_for_fn {
 
                 $crate::private::noop( &mut nth_argument );
 
-                let result = callback.call_mut( ($($kind,)*) );
+                let result = $call;
 
                 let mut result = Some( result );
                 let result = JsSerializeOwned::into_js_owned( &mut result );
@@ -817,78 +823,16 @@ macro_rules! impl_for_fn {
             }
         }
 
-        impl< $($kind: TryFrom< Value >,)* F > FuncallAdapter< F > for Newtype< (FunctionTag, ($($kind,)*)), Once< F > >
-            where F: CallOnce< ($($kind,)*) > + 'static, F::Output: JsSerializeOwned
-        {
-            #[allow(unused_mut, unused_variables, non_snake_case)]
-            extern fn funcall_adapter(
-                    callback: *mut F,
-                    raw_arguments: *mut SerializedUntaggedArray
-                )
-            {
-                debug_assert_ne!( callback, 0 as *mut F );
-
-                let callback = unsafe {
-                    Box::from_raw( callback )
-                };
-
-                let mut arguments = unsafe { &*raw_arguments }.deserialize();
-                unsafe {
-                    ffi::dealloc( raw_arguments as *mut u8, mem::size_of::< SerializedValue >() );
-                }
-
-                if arguments.len() != F::expected_argument_count() {
-                    // TODO: Should probably throw an exception into the JS world or something like that.
-                    panic!( "Expected {} arguments, got {}", F::expected_argument_count(), arguments.len() );
-                }
-
-                let mut arguments = arguments.drain( .. );
-                let mut nth_argument = 0;
-                $(
-                    let $kind = match arguments.next().unwrap().try_into() {
-                        Ok( value ) => value,
-                        Err( _ ) => {
-                            panic!(
-                                "Argument #{} is not convertible to '{}'",
-                                nth_argument + 1,
-                                type_name::< $kind >()
-                            );
-                        }
-                    };
-
-                    nth_argument += 1;
-                )*
-
-                $crate::private::noop( &mut nth_argument );
-
-                let result = callback.call_once( ($($kind,)*) );
-
-                let mut result = Some( result );
-                let result = JsSerializeOwned::into_js_owned( &mut result );
-                let result = &result as *const _;
-
-                // This is kinda hacky but I'm not sure how else to do it at the moment.
-                __js_raw_asm!( "Module.STDWEB_PRIVATE.tmp = Module.STDWEB_PRIVATE.to_js( $0 );", result );
-            }
-
-            extern fn deallocator( callback: *mut F ) {
-                let callback = unsafe {
-                    Box::from_raw( callback )
-                };
-
-                drop( callback );
-            }
-        }
-
-        impl< $($kind: TryFrom< Value >,)* F > JsSerializeOwned for Newtype< (FunctionTag, ($($kind,)*)), Once< F > >
-            where F: CallOnce< ($($kind,)*) > + 'static, F::Output: JsSerializeOwned
+        impl< $($kind: TryFrom< Value >,)* F > JsSerializeOwned for Newtype< (FunctionTag, ($($kind,)*)), $wrappedtype >
+            where F: $trait< ($($kind,)*) > + 'static, F::Output: JsSerializeOwned
         {
             #[inline]
             fn into_js_owned< 'a >( value: &'a mut Option< Self > ) -> SerializedValue< 'a > {
-                let callback: *mut F = Box::into_raw( Box::new( value.take().unwrap().unwrap_newtype().0 ) );
+                let $wrapped = value.take().unwrap().unwrap_newtype();
+                let callback: *mut F = Box::into_raw( Box::new( $unwrap ) );
                 let adapter_pointer = <Self as FuncallAdapter< F > >::funcall_adapter;
                 let deallocator_pointer = <Self as FuncallAdapter< F > >::deallocator;
-                SerializedUntaggedFunctionOnce {
+                $serialized_to {
                     adapter_pointer: adapter_pointer as u32,
                     pointer: callback as u32,
                     deallocator_pointer: deallocator_pointer as u32
@@ -896,32 +840,16 @@ macro_rules! impl_for_fn {
             }
         }
 
-        impl< $($kind: TryFrom< Value >,)* F > JsSerializeOwned for Newtype< (FunctionTag, ($($kind,)*)), F >
-            where F: Call< ($($kind,)*) > + 'static, F::Output: JsSerializeOwned
+        impl< $($kind: TryFrom< Value >,)* F > JsSerializeOwned for Newtype< (FunctionTag, ($($kind,)*)), Option< $wrappedtype > >
+            where F: $trait< ($($kind,)*) > + 'static, F::Output: JsSerializeOwned
         {
             #[inline]
             fn into_js_owned< 'a >( value: &'a mut Option< Self > ) -> SerializedValue< 'a > {
-                let callback: *mut F = Box::into_raw( Box::new( value.take().unwrap().unwrap_newtype() ) );
-                let adapter_pointer = <Self as FuncallAdapter< F > >::funcall_adapter;
-                let deallocator_pointer = <Self as FuncallAdapter< F > >::deallocator;
-                SerializedUntaggedFunction {
-                    adapter_pointer: adapter_pointer as u32,
-                    pointer: callback as u32,
-                    deallocator_pointer: deallocator_pointer as u32
-                }.into()
-            }
-        }
-
-        impl< $($kind: TryFrom< Value >,)* F > JsSerializeOwned for Newtype< (FunctionTag, ($($kind,)*)), Option< F > >
-            where F: Call< ($($kind,)*) > + 'static, F::Output: JsSerializeOwned
-        {
-            #[inline]
-            fn into_js_owned< 'a >( value: &'a mut Option< Self > ) -> SerializedValue< 'a > {
-                if let Some( value ) = value.take().unwrap().unwrap_newtype() {
-                    let callback: *mut F = Box::into_raw( Box::new( value ) );
-                    let adapter_pointer = <Newtype< (FunctionTag, ($($kind,)*)), F > as FuncallAdapter< F > >::funcall_adapter;
-                    let deallocator_pointer = <Newtype< (FunctionTag, ($($kind,)*)), F > as FuncallAdapter< F > >::deallocator;
-                    SerializedUntaggedFunction {
+                if let Some( $wrapped ) = value.take().unwrap().unwrap_newtype() {
+                    let callback: *mut F = Box::into_raw( Box::new( $unwrap ) );
+                    let adapter_pointer = <Newtype< (FunctionTag, ($($kind,)*)), $wrappedtype > as FuncallAdapter< F > >::funcall_adapter;
+                    let deallocator_pointer = <Newtype< (FunctionTag, ($($kind,)*)), $wrappedtype > as FuncallAdapter< F > >::deallocator;
+                    $serialized_to {
                         adapter_pointer: adapter_pointer as u32,
                         pointer: callback as u32,
                         deallocator_pointer: deallocator_pointer as u32
@@ -931,7 +859,29 @@ macro_rules! impl_for_fn {
                 }
             }
         }
+    }
+}
 
+macro_rules! impl_for_fn {
+    ($next:tt => $($kind:ident),*) => {
+        impl_for_fn_and_modifier!(
+            args: ($($kind),*),
+            trait: Call,
+            wrapped type: F,
+            unwrap: f => f,
+            serialized to: SerializedUntaggedFunction,
+            call: f => { unsafe { &mut *f }.call( ($($kind,)*) ) }
+        );
+        
+        impl_for_fn_and_modifier!(
+            args: ($($kind),*),
+            trait: CallOnce,
+            wrapped type: Once<F>,
+            unwrap: f => {f.0},
+            serialized to: SerializedUntaggedFunctionOnce,
+            call: f => { unsafe { Box::from_raw( f ) }.call_once( ($($kind,)*) ) }
+        );
+        
         next! { $next }
     }
 }

--- a/src/webcore/serialization.rs
+++ b/src/webcore/serialization.rs
@@ -6,7 +6,7 @@ use std::marker::PhantomData;
 use std::hash::Hash;
 
 use webcore::ffi;
-use webcore::callfn::{CallOnce, CallMut};
+use webcore::callfn::{CallOnce, Call};
 use webcore::newtype::Newtype;
 use webcore::try_from::{TryFrom, TryInto};
 use webcore::number::Number;
@@ -759,7 +759,7 @@ trait FuncallAdapter< F > {
 macro_rules! impl_for_fn {
     ($next:tt => $($kind:ident),*) => {
         impl< $($kind: TryFrom< Value >,)* F > FuncallAdapter< F > for Newtype< (FunctionTag, ($($kind,)*)), F >
-            where F: CallMut< ($($kind,)*) > + 'static, F::Output: JsSerializeOwned
+            where F: Call< ($($kind,)*) > + 'static, F::Output: JsSerializeOwned
         {
             #[allow(unused_mut, unused_variables, non_snake_case)]
             extern fn funcall_adapter(
@@ -897,7 +897,7 @@ macro_rules! impl_for_fn {
         }
 
         impl< $($kind: TryFrom< Value >,)* F > JsSerializeOwned for Newtype< (FunctionTag, ($($kind,)*)), F >
-            where F: CallMut< ($($kind,)*) > + 'static, F::Output: JsSerializeOwned
+            where F: Call< ($($kind,)*) > + 'static, F::Output: JsSerializeOwned
         {
             #[inline]
             fn into_js_owned< 'a >( value: &'a mut Option< Self > ) -> SerializedValue< 'a > {
@@ -913,7 +913,7 @@ macro_rules! impl_for_fn {
         }
 
         impl< $($kind: TryFrom< Value >,)* F > JsSerializeOwned for Newtype< (FunctionTag, ($($kind,)*)), Option< F > >
-            where F: CallMut< ($($kind,)*) > + 'static, F::Output: JsSerializeOwned
+            where F: Call< ($($kind,)*) > + 'static, F::Output: JsSerializeOwned
         {
             #[inline]
             fn into_js_owned< 'a >( value: &'a mut Option< Self > ) -> SerializedValue< 'a > {

--- a/src/webcore/serialization.rs
+++ b/src/webcore/serialization.rs
@@ -6,7 +6,7 @@ use std::marker::PhantomData;
 use std::hash::Hash;
 
 use webcore::ffi;
-use webcore::callfn::{CallOnce, CallMut, Call};
+use webcore::callfn::{CallOnce, CallMut};
 use webcore::newtype::Newtype;
 use webcore::try_from::{TryFrom, TryInto};
 use webcore::number::Number;
@@ -878,11 +878,11 @@ macro_rules! impl_for_fn {
     ($next:tt => $($kind:ident),*) => {
         impl_for_fn_and_modifier!(
             args: ($($kind),*),
-            trait: Call,
+            trait: CallMut,
             wrapped type: F,
             unwrap: f => f,
             serialized to: SerializedUntaggedFunction,
-            call: f => { unsafe { &mut *f }.call( ($($kind,)*) ) }
+            call: f => { unsafe { &mut *f }.call_mut( ($($kind,)*) ) }
         );
         
         impl_for_fn_and_modifier!(

--- a/stdweb-internal-runtime/src/runtime.js
+++ b/stdweb-internal-runtime/src/runtime.js
@@ -85,61 +85,61 @@ Module.STDWEB_PRIVATE.to_js = function to_js( address ) {
         return output;
     } else if( kind === 9 ) {
         return Module.STDWEB_PRIVATE.acquire_js_reference( HEAP32[ address / 4 ] );
-    } else if( kind === 10 ) {
+    } else if( kind === 10 || kind === 12 || kind === 13 ) {
         var adapter_pointer = HEAPU32[ address / 4 ];
         var pointer = HEAPU32[ (address + 4) / 4 ];
         var deallocator_pointer = HEAPU32[ (address + 8) / 4 ];
+        var num_ongoing_calls = 0;
         var output = function() {
             if( pointer === 0 ) {
-                throw new ReferenceError( "Already dropped Rust function called!" );
+                if (kind === 10) {
+                    throw new ReferenceError( "Already dropped Rust function called!" );
+                } else if (kind === 12) {
+                    throw new ReferenceError( "Already dropped FnMut function called!" );
+                } else {
+                    throw new ReferenceError( "Already called or dropped FnOnce function called!" );
+                }
+            }
+            
+            var function_pointer = pointer;
+            if (kind === 13) {
+                output.drop = Module.STDWEB_PRIVATE.noop;
+                pointer = 0;
+            }
+
+            if (num_ongoing_calls !== 0) {
+                if (kind === 12 || kind === 13) {
+                    throw new ReferenceError( "FnMut function called multiple times concurrently!" );
+                }
             }
 
             var args = Module.STDWEB_PRIVATE.alloc( 16 );
             Module.STDWEB_PRIVATE.serialize_array( args, arguments );
-            Module.STDWEB_PRIVATE.dyncall( "vii", adapter_pointer, [pointer, args] );
-            var result = Module.STDWEB_PRIVATE.tmp;
-            Module.STDWEB_PRIVATE.tmp = null;
+
+            try {
+                num_ongoing_calls += 1;
+                Module.STDWEB_PRIVATE.dyncall( "vii", adapter_pointer, [function_pointer, args] );
+                var result = Module.STDWEB_PRIVATE.tmp;
+                Module.STDWEB_PRIVATE.tmp = null;
+            } finally {
+                num_ongoing_calls -= 1;
+            }
 
             return result;
         };
 
         output.drop = function() {
-            output.drop = Module.STDWEB_PRIVATE.noop;
-            var function_pointer = pointer;
-            pointer = 0;
-
-            Module.STDWEB_PRIVATE.dyncall( "vi", deallocator_pointer, [function_pointer] );
-        };
-
-        return output;
-    } else if( kind === 13 ) {
-        var adapter_pointer = HEAPU32[ address / 4 ];
-        var pointer = HEAPU32[ (address + 4) / 4 ];
-        var deallocator_pointer = HEAPU32[ (address + 8) / 4 ];
-        var output = function() {
-            if( pointer === 0 ) {
-                throw new ReferenceError( "Already called or dropped FnOnce function called!" );
+            if (num_ongoing_calls !== 0) {
+                throw new ReferenceError( "Rust function dropped while called!" );
             }
 
             output.drop = Module.STDWEB_PRIVATE.noop;
             var function_pointer = pointer;
             pointer = 0;
 
-            var args = Module.STDWEB_PRIVATE.alloc( 16 );
-            Module.STDWEB_PRIVATE.serialize_array( args, arguments );
-            Module.STDWEB_PRIVATE.dyncall( "vii", adapter_pointer, [function_pointer, args] );
-            var result = Module.STDWEB_PRIVATE.tmp;
-            Module.STDWEB_PRIVATE.tmp = null;
-
-            return result;
-        };
-
-        output.drop = function() {
-            output.drop = Module.STDWEB_PRIVATE.noop;
-            var function_pointer = pointer;
-            pointer = 0;
-
-            Module.STDWEB_PRIVATE.dyncall( "vi", deallocator_pointer, [function_pointer] );
+            if (function_pointer != 0) {
+                Module.STDWEB_PRIVATE.dyncall( "vi", deallocator_pointer, [function_pointer] );
+            }
         };
 
         return output;


### PR DESCRIPTION
This PR supersedes PR #274, and fixes issues #273, #277 and #278.

This PR implements the `Mut` modifier discussed in issue #273. The `js!` macro now only accepts `Fn` closures, and to use `FnMut` closures you need to wrap them in `Mut(...)`, very similar to the situation with `FnOnce` and `Once(...)`.

Interestingly, a closure with a `Mut` modifier is not slower than a regular closure, because even regular closures need to keep track of ongoing calls due to issue #278.

When the runtime detects any illegal recursion or premature drops, a `ReferenceError ` is thrown to the JavaScript world (as it already did when a dropped closure was called).