### PR TITLE
Custom Elements: CustomElementRegistry

### DIFF
--- a/src/webapi/custom_elements.rs
+++ b/src/webapi/custom_elements.rs
@@ -1,0 +1,62 @@
+use webcore::value::Reference;
+webapi::error::TypeError;
+
+use webapi::dom_exception::{
+    NotSupportedError,
+    SyntaxError
+};
+
+#[cfg(feature = "experimental_features_which_may_break_on_minor_version_bumps")]
+use webcore::promise::{Promise, TypedPromise};
+
+/// The CustomElementRegistry interface provides methods for registering custom elements 
+/// and querying registered elements. To get an instance of it, use the window.customElements property. 
+///
+/// [(JavaScript docs)](hhttps://developer.mozilla.org/en-US/docs/Web/API/CustomElementRegistry)
+/// https://html.spec.whatwg.org/multipage/custom-elements.html#customelementregistry
+#[derive(Clone, Debug, PartialEq, Eq, ReferenceType)]
+#[reference(instance_of = "CustomElementRegistry")]
+pub struct CustomElementRegistry(Reference);
+
+
+error_enum_boilerplate! {
+    /// A enum of the exceptions that CustomElementRegistry.define() may throw
+    DefineError,
+    /// A TypeError
+    TypeError
+    /// A NotSupportedError
+    NotSupportedError,
+    /// A SyntaxError
+    SyntaxError,
+}
+
+impl CustomElementRegistry {
+    /// Defines a new custom element
+    ///
+    /// [(JavaScript docs)](https://developer.mozilla.org/en-US/docs/Web/API/CustomElementRegistry/define)
+    /// https://html.spec.whatwg.org/multipage/custom-elements.html#dom-customelementregistry-define
+    pub fn define( &self, name: &str, constructor: Any) -> Result<(), DefineError> {
+        js!(
+            return @{self}.define(name, constructor); 
+        ).try_into().unwrap()
+    }
+
+    /// Returns the constuctor for the named custom element, or undefined if the custom element is not defined.
+    ///
+    /// [(JavaScript docs)](https://developer.mozilla.org/en-US/docs/Web/API/CustomElementRegistry/get)
+    /// https://html.spec.whatwg.org/multipage/custom-elements.html#dom-customelementregistry-get
+    pub fn get( &self, name: &str ) -> Option<Constructor> {
+        js!( return @{self}.get(name); ).try_into().unwrap()
+    }
+
+    /// Returns a promise that will be fulfilled when a custom element becomes defined with the given name.
+    /// (If such a custom element is already defined, the returned promise is immediately fulfilled.)
+    ///
+    /// [(JavaScript docs)](https://developer.mozilla.org/en-US/docs/Web/API/CustomElementRegistry/whenDefined)
+    /// https://html.spec.whatwg.org/multipage/custom-elements.html#dom-customelementregistry-whendefined
+    #[cfg(feature = "experimental_features_which_may_break_on_minor_version_bumps")]
+    pub fn whenDefined( &self, name: &str ) -> TypedPromise<(), SyntaxError > {
+        let promise: Promise = js!( return @{self}.whenDefined(name); ).try_into().unwrap();
+        TypedPromise::new(promise)
+    })
+}


### PR DESCRIPTION
[WIP] Initial impl of `CustomElementRegistry`

I do have a few questions before completing this:

1. How exactly do I represent a Constructor here? (https://github.com/koute/stdweb/compare/master...prasannavl:patch-1#diff-55e0c9ca42d6126fc52bcae5a9a2bf95R38)
1. Is it okay to unwrap, this? Initially I did a `no_return`, but then added the error type, and as such the `Result<(), Err>`. Does this fit the project conventions? (https://github.com/koute/stdweb/compare/master...prasannavl:patch-1#diff-55e0c9ca42d6126fc52bcae5a9a2bf95R41)
1. Again, constructor type. But also, can `Option` be returned. Does this fit the project conventions, or should this be a result with empty error/not found error? What's the best way to represent `undefined` here. (https://github.com/koute/stdweb/compare/master...prasannavl:patch-1#diff-55e0c9ca42d6126fc52bcae5a9a2bf95R48)
1. I followed this convention by looking at other implementations, but it is correct to unwrap this? (https://github.com/koute/stdweb/compare/master...prasannavl:patch-1#diff-55e0c9ca42d6126fc52bcae5a9a2bf95R48)