### PR TITLE
Huge string performance boost

### DIFF
--- a/stdweb-internal-runtime/src/runtime.js
+++ b/stdweb-internal-runtime/src/runtime.js
@@ -210,7 +210,7 @@ Module.STDWEB_PRIVATE.serialize_array = function serialize_array( address, value
 // New browsers and recent Node
 var cachedEncoder = ( typeof TextEncoder === "function"
     ? new TextEncoder( "utf-8" )
-    // Old Node
+    // Old Node (before v11)
     : ( util && typeof util === "object" && typeof util.TextEncoder === "function"
         ? new util.TextEncoder( "utf-8" )
         // Old browsers
@@ -281,7 +281,7 @@ Module.STDWEB_PRIVATE.from_js = function from_js( address, value ) {
 // New browsers and recent Node
 var cachedDecoder = ( typeof TextDecoder === "function"
     ? new TextDecoder( "utf-8" )
-    // Old Node
+    // Old Node (before v11)
     : ( util && typeof util === "object" && typeof util.TextDecoder === "function"
         ? new util.TextDecoder( "utf-8" )
         // Old browsers

--- a/stdweb-internal-runtime/src/runtime.js
+++ b/stdweb-internal-runtime/src/runtime.js
@@ -207,9 +207,16 @@ Module.STDWEB_PRIVATE.serialize_array = function serialize_array( address, value
     }
 };
 
-if ( typeof TextEncoder === "function" ) {
-    var cachedEncoder = new TextEncoder( "utf-8" );
+// New browsers and recent Node
+var cachedEncoder = ( typeof TextEncoder === "function"
+    ? new TextEncoder( "utf-8" )
+    // Old Node
+    : ( util && typeof util === "object" && typeof util.TextEncoder === "function"
+        ? new util.TextEncoder( "utf-8" )
+        // Old browsers
+        : null ) );
 
+if ( cachedEncoder != null ) {
     Module.STDWEB_PRIVATE.to_utf8_string = function to_utf8_string( address, value ) {
         var buffer = cachedEncoder.encode( value );
         var length = buffer.length;
@@ -271,9 +278,16 @@ Module.STDWEB_PRIVATE.from_js = function from_js( address, value ) {
     }
 };
 
-if ( typeof TextDecoder === "function" ) {
-    var cachedDecoder = new TextDecoder( "utf-8" );
+// New browsers and recent Node
+var cachedDecoder = ( typeof TextDecoder === "function"
+    ? new TextDecoder( "utf-8" )
+    // Old Node
+    : ( util && typeof util === "object" && typeof util.TextDecoder === "function"
+        ? new util.TextDecoder( "utf-8" )
+        // Old browsers
+        : null ) );
 
+if ( cachedDecoder != null ) {
     Module.STDWEB_PRIVATE.to_js_string = function to_js_string( index, length ) {
         return cachedDecoder.decode( HEAPU8.subarray( index, index + length ) );
     };

--- a/stdweb-internal-runtime/src/runtime.js
+++ b/stdweb-internal-runtime/src/runtime.js
@@ -211,7 +211,7 @@ Module.STDWEB_PRIVATE.serialize_array = function serialize_array( address, value
 var cachedEncoder = ( typeof TextEncoder === "function"
     ? new TextEncoder( "utf-8" )
     // Old Node (before v11)
-    : ( util && typeof util === "object" && typeof util.TextEncoder === "function"
+    : ( typeof util === "object" && util && typeof util.TextEncoder === "function"
         ? new util.TextEncoder( "utf-8" )
         // Old browsers
         : null ) );
@@ -282,7 +282,7 @@ Module.STDWEB_PRIVATE.from_js = function from_js( address, value ) {
 var cachedDecoder = ( typeof TextDecoder === "function"
     ? new TextDecoder( "utf-8" )
     // Old Node (before v11)
-    : ( util && typeof util === "object" && typeof util.TextDecoder === "function"
+    : ( typeof util === "object" && util && typeof util.TextDecoder === "function"
         ? new util.TextDecoder( "utf-8" )
         // Old browsers
         : null ) );


### PR DESCRIPTION
I noticed that when passing large strings from Rust to JS, it takes a long time.

This PR fixes that, by using the browser's built-in `TextDecoder` and `TextEncoder` features, if they are available (if they're not available it continues to use the old behavior). This is what wasm-bindgen does (which is how I found out about it).

When passing a large string to JS, the old code took ~19,115ms, but with this PR it now takes ~364ms!

As usual, it's best to review with [whitespace ignored](https://github.com/koute/stdweb/pull/300/files?utf8=%E2%9C%93&diff=split&w=1).