### PR TITLE
fix Runtime.dynCall is not a function

### DIFF
--- a/stdweb-internal-runtime/src/runtime_emscripten.js
+++ b/stdweb-internal-runtime/src/runtime_emscripten.js
@@ -3,7 +3,7 @@ Module.STDWEB_PRIVATE.alloc = function alloc( size ) {
 };
 
 Module.STDWEB_PRIVATE.dyncall = function( signature, ptr, args ) {
-    return Runtime.dynCall( signature, ptr, args );
+    return dynCall( signature, ptr, args );
 };
 
 Module.STDWEB_PRIVATE.utf8_len = function utf8_len( str ) {


### PR DESCRIPTION
**steps to reproduce**
```sh
cd examples/canvas
cargo web start --target=wasm32-unknown-emscripten
open http://localhost:8000
# look in console
```
similar issue https://github.com/emscripten-core/emscripten/issues/8018