### PR TITLE
Updating to the stable Futures API

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,10 +17,10 @@ build = "build.rs"
 discard = "1.0.3"
 serde = { version = "1", optional = true }
 serde_json = { version = "1", optional = true }
-futures-core-preview = { version = "0.3.0-alpha.13", optional = true }
-futures-channel-preview = { version = "0.3.0-alpha.13", optional = true }
-futures-util-preview = { version = "0.3.0-alpha.13", optional = true }
-futures-executor-preview = { version = "0.3.0-alpha.13", optional = true }
+futures-core-preview = { version = "0.3.0-alpha.15", optional = true }
+futures-channel-preview = { version = "0.3.0-alpha.15", optional = true }
+futures-util-preview = { version = "0.3.0-alpha.15", optional = true }
+futures-executor-preview = { version = "0.3.0-alpha.15", optional = true }
 
 stdweb-derive = { version = "= 0.5.1", path = "stdweb-derive" }
 stdweb-internal-macros = { version = "= 0.2.7", path = "stdweb-internal-macros" }

--- a/examples/futures/Cargo.toml
+++ b/examples/futures/Cargo.toml
@@ -6,4 +6,4 @@ authors = ["Jan Bujak <j@exia.io>"]
 
 [dependencies]
 stdweb = { path = "../..", features = ["experimental_features_which_may_break_on_minor_version_bumps", "nightly"] }
-futures-preview = "0.3.0-alpha.13"
+futures-preview = "0.3.0-alpha.15"

--- a/examples/futures/src/main.rs
+++ b/examples/futures/src/main.rs
@@ -1,9 +1,9 @@
-#![feature(async_await, await_macro, futures_api)]
+#![feature(async_await, await_macro)]
 
 #[macro_use]
 extern crate stdweb;
 
-use futures::{join, try_join};
+use futures::future::{join, try_join};
 use stdweb::{PromiseFuture, spawn_local, unwrap_future};
 use stdweb::web::wait;
 use stdweb::web::error::Error;
@@ -35,23 +35,23 @@ async fn future_main() -> Result< (), Error > {
     await!( print( "There" ) );
 
     {
-        let a = print( "Test 1" );
-        let b = print( "Test 2" );
-
         // Runs multiple Futures in parallel
-        let ( a, b ) = join!( a, b );
+        let ( a, b ) = await!( join(
+            print( "Test 1" ),
+            print( "Test 2" ),
+        ) );
 
-        console!( log, "Done", a, b );
+        console!( log, "join", a, b );
     }
 
     {
-        let a = javascript_promise();
-        let b = javascript_promise();
-
         // Runs multiple Futures (which can error) in parallel
-        let ( a, b ) = try_join!( a, b )?;
+        let ( a, b ) = await!( try_join(
+            javascript_promise(),
+            javascript_promise(),
+        ) )?;
 
-        console!( log, a, b );
+        console!( log, "try_join", a, b );
     }
 
     Ok( () )

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -116,7 +116,6 @@
 )]
 #![cfg_attr(rust_nightly, feature(core_intrinsics))]
 #![cfg_attr(feature = "nightly", feature(never_type))]
-#![cfg_attr(feature = "futures-support", feature(futures_api, pin, arbitrary_self_types))]
 #![recursion_limit="1500"]
 
 #[cfg(feature = "serde")]

--- a/src/webcore/executor.rs
+++ b/src/webcore/executor.rs
@@ -5,11 +5,12 @@
 // TODO: verify that this works correctly with pinned futures
 // TODO: use FuturesUnordered (similar to LocalPool)
 
-use futures_core::{Future, Poll};
 use futures_core::future::{FutureObj, LocalFutureObj};
 use futures_executor::enter;
 use futures_core::task::{Spawn, SpawnError};
 use futures_util::task::ArcWake;
+use std::future::Future;
+use std::task::{Poll, Context};
 use std::pin::Pin;
 use std::rc::Rc;
 use std::cell::{Cell, RefCell};
@@ -71,10 +72,11 @@ impl Task {
         let poll = {
             // TODO is there some way of saving these so they don't need to be recreated all the time ?
             let waker = ArcWake::into_waker( arc.clone() );
+            let cx = &mut Context::from_waker( &waker );
 
             // TODO what if poll panics ?
             // TODO is this Pin correct ?
-            Pin::new( &mut lock.future ).poll( &waker )
+            Pin::new( &mut lock.future ).poll( cx )
         };
 
         if let Poll::Pending = poll {
@@ -97,7 +99,7 @@ impl Task {
 
 impl ArcWake for Task {
     #[inline]
-    fn wake( arc_self: &Arc< Self > ) {
+    fn wake_by_ref( arc_self: &Arc< Self > ) {
         Task::push_task( arc_self );
     }
 }

--- a/src/webcore/promise_future.rs
+++ b/src/webcore/promise_future.rs
@@ -1,11 +1,12 @@
 use std;
 use std::pin::Pin;
+use std::future::Future;
+use std::task::{Poll, Context};
 use webcore::value::{Value, ConversionError};
 use webcore::try_from::{TryInto, TryFrom};
 use webcore::executor;
 use webapi::error;
-use futures_core::{Future, TryFuture, Poll};
-use futures_core::task::Waker;
+use futures_core::TryFuture;
 use futures_util::{FutureExt, TryFutureExt};
 use futures_channel::oneshot::Receiver;
 use webcore::discard::DiscardOnDrop;
@@ -189,9 +190,9 @@ impl< A, B > Future for PromiseFuture< A, B > {
     type Output = Result< A, B >;
 
     #[inline]
-    fn poll( mut self: Pin< &mut Self >, waker: &Waker ) -> Poll< Self::Output > {
+    fn poll( mut self: Pin< &mut Self >, cx: &mut Context ) -> Poll< Self::Output > {
         // TODO maybe remove this unwrap ?
-        self.future.poll_unpin( waker ).map( |x| x.unwrap() )
+        self.future.poll_unpin( cx ).map( |x| x.unwrap() )
     }
 }
 


### PR DESCRIPTION
The Future trait was recently stabilized. There were some last-minute changes, so this PR fixes stdweb to work with the latest Rust compiler.

Hopefully there shouldn't be any more changes (and Future will soon be available in Stable).