### PR TITLE
Add the clear_timeout method to IWindowOrWorker

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -284,6 +284,7 @@ pub mod web {
     pub use webapi::shadow_root::{ShadowRootMode, ShadowRoot};
     pub use webapi::html_elements::SlotContentKind;
     pub use webapi::form_data::{FormData, FormDataEntry};
+    pub use webapi::window_or_worker::TimeoutHandle;
 
     /// A module containing error types.
     pub mod error {

--- a/src/webapi/window_or_worker.rs
+++ b/src/webapi/window_or_worker.rs
@@ -21,12 +21,22 @@ pub trait IWindowOrWorker: ReferenceType {
     ///
     /// [(JavaScript docs)](https://developer.mozilla.org/en-US/docs/Web/API/WindowOrWorkerGlobalScope/setTimeout)
     // https://html.spec.whatwg.org/#windoworworkerglobalscope-mixin:dom-settimeout
-    fn set_timeout< F: FnOnce() + 'static >( &self, callback: F, timeout: u32 ) {
+    fn set_timeout< F: FnOnce() + 'static >( &self, callback: F, timeout: u32 ) -> i32 {
         let callback = Box::into_raw( Box::new( callback ) );
         __js_raw_asm!( "\
             Module.STDWEB_PRIVATE.acquire_js_reference( $0 ).setTimeout( function() {\
                 Module.STDWEB_PRIVATE.dyncall( 'vi', $1, [$2] );\
             }, $3 );\
-        ", self.as_ref().as_raw(), funcall_adapter::< F > as extern fn( *mut F ), callback, timeout );
+        ", self.as_ref().as_raw(), funcall_adapter::< F > as extern fn( *mut F ), callback, timeout )
+    }
+
+    /// Clears a timer previously established by set_timeout
+    ///
+    /// [(JavaScript docs)](https://developer.mozilla.org/en-US/docs/Web/API/WindowOrWorkerGlobalScope/clearTimeout)
+    // https://html.spec.whatwg.org/#windoworworkerglobalscope-mixin:dom-clear-timeout
+    fn clear_timeout( &self, id: i32 ) {
+        js! {
+            clearTimeout(@{id})
+        }
     }
 }

--- a/src/webapi/window_or_worker.rs
+++ b/src/webapi/window_or_worker.rs
@@ -1,4 +1,6 @@
+use webcore::value::Reference;
 use webcore::reference_type::ReferenceType;
+use webcore::try_from::TryInto;
 
 extern fn funcall_adapter< F: FnOnce() >( callback: *mut F ) {
     let callback = unsafe {
@@ -35,8 +37,8 @@ pub trait IWindowOrWorker: ReferenceType {
     /// [(JavaScript docs)](https://developer.mozilla.org/en-US/docs/Web/API/WindowOrWorkerGlobalScope/setTimeout)
     // https://html.spec.whatwg.org/#windoworworkerglobalscope-mixin:dom-settimeout
     fn set_clearable_timeout< F: FnOnce() + 'static >( &self, callback: F, timeout: u32 ) -> TimeoutHandle {
-        let callback = Box::into_raw( Box::new( callback ) );
-        let callback_reference: Reference = js! ( return @{Mut(callback)}; ).try_into().unwrap();
+        //let callback = Box::into_raw( Box::new( callback ) );
+        let callback_reference: Reference = js! ( return @{callback}; ).try_into().unwrap();
         let id = js! {
             setTimeout(@{callback_reference}, @{timeout});
         }.try_into().unwrap();

--- a/src/webapi/window_or_worker.rs
+++ b/src/webapi/window_or_worker.rs
@@ -49,6 +49,7 @@ pub trait IWindowOrWorker: ReferenceType {
 }
 
 #[derive(Debug)]
+/// A reference to a timeout object created by set_clearable_timeout
 pub struct TimeoutHandle(Object);
 
 impl TimeoutHandle {

--- a/src/webapi/window_or_worker.rs
+++ b/src/webapi/window_or_worker.rs
@@ -1,7 +1,6 @@
-use webcore::object::Object;
 use webcore::once::Once;
+use webcore::value::Value;
 use webcore::reference_type::ReferenceType;
-use webcore::try_from::TryInto;
 
 extern fn funcall_adapter< F: FnOnce() >( callback: *mut F ) {
     let callback = unsafe {
@@ -44,23 +43,24 @@ pub trait IWindowOrWorker: ReferenceType {
                 id: setTimeout(callback, @{timeout}),
                 callback
             };
-        ).try_into().unwrap())
+        ))
     }
 }
 
 #[derive(Debug)]
 /// A reference to a timeout object created by set_clearable_timeout
-pub struct TimeoutHandle(Object);
+pub struct TimeoutHandle(Value);
 
 impl TimeoutHandle {
     /// Clears a timer previously established by set_clearable_timeout
     ///
     /// [(JavaScript docs)](https://developer.mozilla.org/en-US/docs/Web/API/WindowOrWorkerGlobalScope/clearTimeout)
     // https://html.spec.whatwg.org/#windoworworkerglobalscope-mixin:dom-clear-timeout
-     pub fn clear( & self ) {
+     pub fn clear( self ) {
         js! { @(no_return)
-            clearTimeout(@{&self.0}.id);
-            @{&self.0}.callback.drop();
+            var val = @{&self.0};
+            clearTimeout(val.id);
+            val.callback.drop();
         }
     }
 }

--- a/src/webapi/window_or_worker.rs
+++ b/src/webapi/window_or_worker.rs
@@ -22,7 +22,12 @@ pub trait IWindowOrWorker: ReferenceType {
     /// [(JavaScript docs)](https://developer.mozilla.org/en-US/docs/Web/API/WindowOrWorkerGlobalScope/setTimeout)
     // https://html.spec.whatwg.org/#windoworworkerglobalscope-mixin:dom-settimeout
     fn set_timeout< F: FnOnce() + 'static >( &self, callback: F, timeout: u32 ) {
-        set_clearable_tmeout(callback, timeout);
+        let callback = Box::into_raw( Box::new( callback ) );
+        __js_raw_asm!( "\
+            Module.STDWEB_PRIVATE.acquire_js_reference( $0 ).setTimeout( function() {\
+                Module.STDWEB_PRIVATE.dyncall( 'vi', $1, [$2] );\
+            }, $3 );\
+        ", self.as_ref().as_raw(), funcall_adapter::< F > as extern fn( *mut F ), callback, timeout );
     }
 
     /// Sets a timer which executes a function once after the timer expires and can be cleared

--- a/src/webapi/window_or_worker.rs
+++ b/src/webapi/window_or_worker.rs
@@ -21,22 +21,36 @@ pub trait IWindowOrWorker: ReferenceType {
     ///
     /// [(JavaScript docs)](https://developer.mozilla.org/en-US/docs/Web/API/WindowOrWorkerGlobalScope/setTimeout)
     // https://html.spec.whatwg.org/#windoworworkerglobalscope-mixin:dom-settimeout
-    fn set_timeout< F: FnOnce() + 'static >( &self, callback: F, timeout: u32 ) -> i32 {
-        let callback = Box::into_raw( Box::new( callback ) );
-        __js_raw_asm!( "\
-            Module.STDWEB_PRIVATE.acquire_js_reference( $0 ).setTimeout( function() {\
-                Module.STDWEB_PRIVATE.dyncall( 'vi', $1, [$2] );\
-            }, $3 );\
-        ", self.as_ref().as_raw(), funcall_adapter::< F > as extern fn( *mut F ), callback, timeout )
+    fn set_timeout< F: FnOnce() + 'static >( &self, callback: F, timeout: u32 ) {
+        set_clearable_tmeout(callback, timeout);
     }
 
-    /// Clears a timer previously established by set_timeout
+    /// Sets a timer which executes a function once after the timer expires and can be cleared
+    ///
+    /// [(JavaScript docs)](https://developer.mozilla.org/en-US/docs/Web/API/WindowOrWorkerGlobalScope/setTimeout)
+    // https://html.spec.whatwg.org/#windoworworkerglobalscope-mixin:dom-settimeout
+    fn set_clearable_timeout< F: FnOnce() + 'static >( &self, callback: F, timeout: u32 ) -> TimeoutHandle {
+        let callback = Box::into_raw( Box::new( callback ) );
+        let id = __js_raw_asm!( "\
+            return Module.STDWEB_PRIVATE.acquire_js_reference( $0 ).setTimeout( function() {\
+                Module.STDWEB_PRIVATE.dyncall( 'vi', $1, [$2] );\
+            }, $3 );\
+        ", self.as_ref().as_raw(), funcall_adapter::< F > as extern fn( *mut F ), callback, timeout );
+
+        TimeoutHandle(id)
+    }
+}
+
+pub struct TimeoutHandle(i32);
+
+impl TimeoutHandle {
+    /// Clears a timer previously established by set_clearable_timeout
     ///
     /// [(JavaScript docs)](https://developer.mozilla.org/en-US/docs/Web/API/WindowOrWorkerGlobalScope/clearTimeout)
     // https://html.spec.whatwg.org/#windoworworkerglobalscope-mixin:dom-clear-timeout
-    fn clear_timeout( &self, id: i32 ) {
+     pub fn clear( & self ) {
         js! {
-            clearTimeout(@{id})
+            clearTimeout(@{id});
         }
     }
 }


### PR DESCRIPTION
I'm not too sure about the change I made to set_timeout, but I know that in JS set_timeout returns an ID that can be passed to clear_timeout.