### PR TITLE
Don't assume libstd is in the root.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -107,8 +107,7 @@
     missing_docs,
     missing_debug_implementations,
     trivial_numeric_casts,
-    unused_import_braces,
-    unused_qualifications
+    unused_import_braces
 )]
 #![cfg_attr(
     all(test, rust_nightly),
@@ -593,13 +592,13 @@ pub mod private {
     #[derive(Debug)]
     pub struct TODO;
 
-    impl ::std::fmt::Display for TODO {
-        fn fmt( &self, _: &mut ::std::fmt::Formatter ) -> Result< (), ::std::fmt::Error > {
+    impl std::fmt::Display for TODO {
+        fn fmt( &self, _: &mut std::fmt::Formatter ) -> Result< (), std::fmt::Error > {
             unreachable!();
         }
     }
 
-    impl ::std::error::Error for TODO {
+    impl std::error::Error for TODO {
         fn description( &self ) -> &str {
             unreachable!();
         }

--- a/src/webapi/error.rs
+++ b/src/webapi/error.rs
@@ -71,7 +71,7 @@ mod test {
 
     #[test]
     fn test_error() {
-        use ::std::fmt::Write;
+        use std::fmt::Write;
 
         let error: Error = js!(
            return new Error("foo");
@@ -83,7 +83,7 @@ mod test {
         let mut text = String::new();
         write!(&mut text, "{}", error).unwrap();
         assert_eq!(&text, "Error: foo");
-        assert_eq!(::std::error::Error::description(&error), "Error");
+        assert_eq!(std::error::Error::description(&error), "Error");
     }
 
     #[test]

--- a/src/webapi/events/history.rs
+++ b/src/webapi/events/history.rs
@@ -119,11 +119,11 @@ mod tests {
         assert_eq!(event.event_type(), PopStateEvent::EVENT_TYPE);
 
         let state_value: Value = event.state();
-        let state: ::std::collections::BTreeMap<String, Value> = state_value
+        let state: std::collections::BTreeMap<String, Value> = state_value
             .as_object()
             .unwrap()
             .into();
-        let mut expected = ::std::collections::BTreeMap::new();
+        let mut expected = std::collections::BTreeMap::new();
         expected.insert("color".to_string(), "tomato".into());
 
         assert_eq!(state, expected);

--- a/src/webapi/html_elements/select.rs
+++ b/src/webapi/html_elements/select.rs
@@ -12,13 +12,13 @@ use webapi::html_elements::OptionElement;
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct UnknownValueError(String);
 
-impl ::std::fmt::Display for UnknownValueError {
-    fn fmt(&self, formatter: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
+impl std::fmt::Display for UnknownValueError {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
         write!(formatter, "There is no `<option>` element that has value='{}'", self.0)
     }
 }
 
-impl ::std::error::Error for UnknownValueError {
+impl std::error::Error for UnknownValueError {
     fn description(&self) -> &str {
         "There is no `<option>` element that has the given value"
     }

--- a/src/webcore/macros.rs
+++ b/src/webcore/macros.rs
@@ -95,7 +95,7 @@ macro_rules! _js_impl {
 
                         snippet( $($arg_names),* );
                     }} else {{
-                        let mut result: $crate::private::SerializedValue = ::std::default::Default::default();
+                        let mut result: $crate::private::SerializedValue = std::default::Default::default();
                         let result_ptr = &mut result as *mut $crate::private::SerializedValue as *mut _;
 
                         #[$crate::private::js_attr]
@@ -110,7 +110,7 @@ macro_rules! _js_impl {
                 )
             };
 
-            ::std::mem::drop( restore_point );
+            std::mem::drop( restore_point );
             result
         }
     };
@@ -223,13 +223,13 @@ macro_rules! __js_serializable_boilerplate {
 
 macro_rules! error_boilerplate {
     ($type_name:ident) => {
-        impl ::std::fmt::Display for $type_name {
-            fn fmt(&self, formatter: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
+        impl std::fmt::Display for $type_name {
+            fn fmt(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
                 write!(formatter, "{}: {}", stringify!($type_name), self.message())
             }
         }
 
-        impl ::std::error::Error for $type_name {
+        impl std::error::Error for $type_name {
             fn description(&self) -> &str {
                 stringify!($type_name)
             }
@@ -280,8 +280,8 @@ macro_rules! newtype_enum {
                 pub const $variant: $name = $name($value);
             )*
         }
-        impl ::std::fmt::Debug for $name {
-            fn fmt(&self, formatter: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
+        impl std::fmt::Debug for $name {
+            fn fmt(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
                 match self.0 {
                     $($value => write!(formatter, "{}::{}", stringify!($name), stringify!($variant)),)*
                     other => write!(formatter, "{}({})", stringify!($name), other)
@@ -420,15 +420,15 @@ macro_rules! error_enum_boilerplate {
             }
         }
 
-        impl ::std::fmt::Display for $error_name {
-            fn fmt(&self, formatter: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
+        impl std::fmt::Display for $error_name {
+            fn fmt(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
                 match *self {
                     $($error_name::$variant( ref r ) => r.fmt(formatter),)*
                 }
             }
         }
 
-        impl ::std::error::Error for $error_name {
+        impl std::error::Error for $error_name {
             fn description(&self) -> &str {
                 stringify!($error_name)
             }

--- a/stdweb-derive/src/lib.rs
+++ b/stdweb-derive/src/lib.rs
@@ -122,7 +122,7 @@ pub fn derive_reference_type( input: TokenStream ) -> TokenStream {
                         1 => {},
                         2 => {
                             default_args.push( quote! {
-                                ::std::default::Default::default()
+                                std::default::Default::default()
                             });
                         },
                         _ => invalid_structure()

--- a/stdweb-internal-macros/src/macro_js_export.rs
+++ b/stdweb-internal-macros/src/macro_js_export.rs
@@ -138,7 +138,7 @@ fn process( exports: Vec< Export > ) -> proc_macro2::TokenStream {
                     let __result = ::stdweb::private::JsSerializeOwned::into_js_owned( &mut __result );
                     let __result = &__result as *const _;
                     __js_raw_asm!( "Module.STDWEB_PRIVATE.tmp = Module.STDWEB_PRIVATE.to_js( $0 );", __result );
-                    ::std::mem::drop( __arena_restore_point );
+                    std::mem::drop( __arena_restore_point );
                     let __result = ();
                 };
                 export_result_metadata = Some( TypeMetadata::Custom {
@@ -175,7 +175,7 @@ fn process( exports: Vec< Export > ) -> proc_macro2::TokenStream {
                             let pointer = #export_arg_ident as *mut ::stdweb::private::SerializedValue;
                             unsafe {
                                 let value = (&*pointer).deserialize();
-                                ::stdweb::private::__web_free( pointer as *mut u8, ::std::mem::size_of::< ::stdweb::private::SerializedValue >() );
+                                ::stdweb::private::__web_free( pointer as *mut u8, std::mem::size_of::< ::stdweb::private::SerializedValue >() );
                                 value
                             }
                         };


### PR DESCRIPTION
Some of the code in `stdweb` assumes that `std` is always at the root, an uses things like `::std::foo::bar`, while some other code just uses things like `std::foo::bar`. The second usage pattern is correct. `libstd` is not always at the root.

Specifically, [`getrandom`](github.com/rust-random/getrandom) is mostly a `no_std` library, but when using `stdweb` it uses `libstd`. It does this by putting `extern crate std` in the `wasm32` submodule. In this case, `std` is present but not in the root.

This PR changes all uses of `::std::` to just be `std::`.