### PR TITLE
Re-export the unload and beforeunload events via the web::events API

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -332,6 +332,9 @@ pub mod web {
             IUiEvent,
             ConcreteEvent,
 
+            UnloadEvent,
+            BeforeUnloadEvent,
+
             EventPhase
         };
 

--- a/src/webapi/event.rs
+++ b/src/webapi/event.rs
@@ -218,6 +218,7 @@ impl IEvent for Event {}
 // https://html.spec.whatwg.org/multipage/indices.html#event-beforeunload
 #[derive(Clone, Debug, PartialEq, Eq, ReferenceType)]
 #[reference(instance_of = "BeforeUnloadEvent")]
+#[reference(event = "beforeunload")]
 pub struct BeforeUnloadEvent( Reference );
 
 impl IEvent for BeforeUnloadEvent {}
@@ -230,6 +231,7 @@ impl IEvent for BeforeUnloadEvent {}
 // https://html.spec.whatwg.org/multipage/indices.html#event-unload
 #[derive(Clone, Debug, PartialEq, Eq, ReferenceType)]
 #[reference(instance_of = "UnloadEvent")]
+#[reference(event = "unload")]
 pub struct UnloadEvent( Reference );
 
 impl IEvent for UnloadEvent {}


### PR DESCRIPTION
Also make the events concrete so they can be listened for