### PR TITLE
Add support for the fullscreen API

### DIFF
--- a/src/webapi/document.rs
+++ b/src/webapi/document.rs
@@ -196,7 +196,7 @@ impl Document {
     /// Check if the fullscreen API is enabled
     ///
     /// [(JavaScript docs)](https://developer.mozilla.org/en-US/docs/Web/API/Document/fullscreenEnabled)
-    // https://fullscreen.spec.whatwg.org/#dom-document-fullscreenenabled
+    // https://fullscreen.spec.whatwg.org/#ref-for-dom-document-fullscreenenabled
     pub fn fullscreen_enabled( &self ) -> bool {
         match js!( return @{self}.fullscreenEnabled; ) {
             Value::Bool(value) => value,
@@ -207,7 +207,7 @@ impl Document {
     /// Get the current fullscreen element, or None if there is nothing fullscreen
     ///
     /// [(JavaScript docs)](https://developer.mozilla.org/en-US/docs/Web/API/DocumentOrShadowRoot/fullscreenElement)
-    // https://fullscreen.spec.whatwg.org/#dom-document-fullscreenelement
+    // https://fullscreen.spec.whatwg.org/#ref-for-dom-document-fullscreenelement
     pub fn fullscreen_element( &self ) -> Option<Element> {
         Some(js!( return @{self}.fullscreenElement; )
             .into_reference()?
@@ -217,7 +217,8 @@ impl Document {
     /// Request the page return from fullscreen mode to a normal state
     ///
     /// [(JavaScript docs)](https://developer.mozilla.org/en-US/docs/Web/API/Document/exitFullscreen)
-    // https://developer.mozilla.org/en-US/docs/Web/API/Document/exitFullscreen
+    // https://fullscreen.spec.whatwg.org/#dom-document-exitfullscreen
+    #[cfg(feature = "experimental_features_which_may_break_on_minor_version_bumps")]
     pub fn exit_fullscreen(&self) -> TypedPromise<(), TypeError> {
         let promise: Promise = js!( return @{self}.exitFullscreen(); )
             .try_into().unwrap();

--- a/src/webapi/document.rs
+++ b/src/webapi/document.rs
@@ -1,5 +1,7 @@
 use webcore::value::{Reference, Value};
 use webcore::try_from::{TryInto, TryFrom};
+use webcore::promise::{Promise, TypedPromise};
+use webapi::error::TypeError;
 use webapi::event_target::{IEventTarget, EventTarget};
 use webapi::node::{INode, Node, CloneKind};
 use webapi::element::Element;
@@ -189,6 +191,38 @@ impl Document {
         js_try!(
             return @{self}.importNode( @{n.as_ref()}, @{deep} );
         ).unwrap()
+    }
+
+    /// Check if the fullscreen API is enabled
+    ///
+    /// [(JavaScript docs)](https://developer.mozilla.org/en-US/docs/Web/API/Document/fullscreenEnabled)
+    // https://fullscreen.spec.whatwg.org/#dom-document-fullscreenenabled
+    pub fn fullscreen_enabled( &self ) -> bool {
+        match js!( return @{self}.fullscreenEnabled; ) {
+            Value::Bool(value) => value,
+            _ => false, // if the variable is not set as a bool, then assume fullscreen is not supported
+        }
+    }
+
+    /// Get the current fullscreen element, or None if there is nothing fullscreen
+    ///
+    /// [(JavaScript docs)](https://developer.mozilla.org/en-US/docs/Web/API/DocumentOrShadowRoot/fullscreenElement)
+    // https://fullscreen.spec.whatwg.org/#dom-document-fullscreenelement
+    pub fn fullscreen_element( &self ) -> Option<Element> {
+        Some(js!( return @{self}.fullscreenElement; )
+            .into_reference()?
+            .downcast::<Element>()?)
+    }
+
+    /// Request the page return from fullscreen mode to a normal state
+    ///
+    /// [(JavaScript docs)](https://developer.mozilla.org/en-US/docs/Web/API/Document/exitFullscreen)
+    // https://developer.mozilla.org/en-US/docs/Web/API/Document/exitFullscreen
+    pub fn exit_fullscreen(&self) -> TypedPromise<(), TypeError> {
+        let promise: Promise = js!( return @{self}.exitFullscreen(); )
+            .try_into().unwrap();
+
+        TypedPromise::new( promise )
     }
 }
 

--- a/src/webapi/element.rs
+++ b/src/webapi/element.rs
@@ -1,5 +1,7 @@
 use webcore::value::Reference;
 use webcore::try_from::{TryFrom, TryInto};
+use webcore::promise::{Promise, TypedPromise};
+use webapi::error::TypeError;
 use webapi::dom_exception::{InvalidCharacterError, InvalidPointerId, NoModificationAllowedError, SyntaxError};
 use webapi::event_target::{IEventTarget, EventTarget};
 use webapi::node::{INode, Node};
@@ -265,6 +267,19 @@ pub trait IElement: INode + IParentNode + IChildNode + ISlotable {
                 return @{self.as_ref()}.shadowRoot;
             ).into_reference_unchecked()
         }
+    }
+
+    /// Request this element and its children be made fullscreen
+    ///
+    /// Note: this may only be called during a user interaction.
+    /// Not all elements may be full-screened, see JS docs for details.
+    /// [(JavaScript docs)](https://developer.mozilla.org/en-US/docs/Web/API/Element/requestFullscreen)
+    // https://fullscreen.spec.whatwg.org/#dom-element-requestfullscreen
+    fn request_fullscreen( &self ) -> TypedPromise<(), TypeError> {
+        let promise: Promise = js!( return @{self.as_ref()}.requestFullscreen(); )
+            .try_into().unwrap();
+
+        TypedPromise::new( promise )
     }
 }
 

--- a/src/webapi/element.rs
+++ b/src/webapi/element.rs
@@ -274,7 +274,8 @@ pub trait IElement: INode + IParentNode + IChildNode + ISlotable {
     /// Note: this may only be called during a user interaction.
     /// Not all elements may be full-screened, see JS docs for details.
     /// [(JavaScript docs)](https://developer.mozilla.org/en-US/docs/Web/API/Element/requestFullscreen)
-    // https://fullscreen.spec.whatwg.org/#dom-element-requestfullscreen
+    // https://fullscreen.spec.whatwg.org/#ref-for-dom-element-requestfullscreen
+    #[cfg(feature = "experimental_features_which_may_break_on_minor_version_bumps")]
     fn request_fullscreen( &self ) -> TypedPromise<(), TypeError> {
         let promise: Promise = js!( return @{self.as_ref()}.requestFullscreen(); )
             .try_into().unwrap();


### PR DESCRIPTION
It requires a few new accessors in Document and a method in Element to request fullscreen, and a method in Document to clear fullscreen.