### PR TITLE
Add Object::to_iter for retrieving an object's keys and values without allocating a rust collection

### DIFF
--- a/src/webcore/object.rs
+++ b/src/webcore/object.rs
@@ -1,5 +1,4 @@
 use std::collections::{BTreeMap, HashMap};
-use std::iter::FromIterator;
 use std::hash::Hash;
 use webcore::try_from::{TryFrom, TryInto};
 use webcore::value::{Reference, Value, ConversionError};
@@ -16,38 +15,6 @@ impl Object {
         js!(
             return Object.keys( @{self} ).length;
         ).try_into().unwrap()
-    }
-
-    /// Converts this object into a map, parsing the keys from the strings stored in JavaScript.
-    ///
-    /// # Example:
-    ///
-    /// ```
-    /// # use stdweb::{ js, unstable::TryFrom };
-    /// use stdweb::serde::ConversionError;
-    /// use serde::de::Error;
-    ///
-    /// let obj: Object = js! { return { 1: 2 } };
-    ///
-    /// let map: HashMap< i32, i32 > = obj.to_map_parsing_keys( |k| {
-    ///     k.parse().map_err( |e| ConversionError::custom(e).into() )
-    /// } )?;
-    ///
-    /// assert_eq!( map[1], 2 );
-    /// ```
-    pub fn to_map_parsing_keys< O, K, V, F, E >( &self, mut parse_keys: F ) -> Result < O, ConversionError >
-        where O: FromIterator< ( K, V ) >,
-              F: FnMut( String ) -> Result< K, ConversionError >,
-              V: TryFrom< Value, Error = E >,
-              E: Into< ConversionError > {
-        deserialize_object( self.as_ref(), |deserializer| -> Result< O, ConversionError > {
-            deserializer
-                .map( |( key, value )| Ok( (
-                    parse_keys(key)?,
-                    value.try_into().map_err( Into::into )?
-                ) ) )
-                .collect::< Result< O, ConversionError > >()
-        })
     }
 }
 

--- a/src/webcore/serialization.rs
+++ b/src/webcore/serialization.rs
@@ -284,7 +284,7 @@ impl Iterator for ObjectDeserializer {
 
 impl ExactSizeIterator for ObjectDeserializer {}
 
-pub fn deserialize_object< R, F: FnOnce( &mut ObjectDeserializer ) -> R >( reference: &Reference, callback: F ) -> R {
+pub fn deserialize_object_to_iter( reference: &Reference ) -> ObjectDeserializer {
     let mut result: SerializedValue = Default::default();
     __js_raw_asm!( "\
         var object = Module.STDWEB_PRIVATE.acquire_js_reference( $0 );\
@@ -307,11 +307,15 @@ pub fn deserialize_object< R, F: FnOnce( &mut ObjectDeserializer ) -> R >( refer
     let key_slice = unsafe { OwnedFfiSlice::new( key_pointer, length ) };
     let value_slice = unsafe { OwnedFfiSlice::new( value_pointer, length ) };
 
-    let mut iter = ObjectDeserializer {
+    ObjectDeserializer {
         key_slice,
         value_slice,
         index: 0
-    };
+    }
+}
+
+pub fn deserialize_object< R, F: FnOnce( &mut ObjectDeserializer ) -> R >( reference: &Reference, callback: F ) -> R {
+    let mut iter = deserialize_object_to_iter( reference );
 
     let output = callback( &mut iter );
 


### PR DESCRIPTION
This could be a bit overzealous, but here it is.

This allows converting an `Object` into a container like `HashMap<i32, V>` rather than only `HashMap<String, V>`, as well as any other map-like thing. It uses a user-provided parsing function to parse the string keys into the other type.

I can make this less permissive if needed - especially since I was only originally thinking about HashMaps.

Fixes #359.