### PR TITLE
fix futures example to work with current nightly (2019-08-18)

### DIFF
--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -1,2 +1,2 @@
 [workspace]
-members = ["canvas", "drag", "echo", "gamepad", "hasher", "minimal", "todomvc", "webgl", "wasm-bindgen-minimal"]
+members = ["canvas", "drag", "echo", "futures", "gamepad", "hasher", "minimal", "todomvc", "webgl", "wasm-bindgen-minimal"]

--- a/examples/futures/src/main.rs
+++ b/examples/futures/src/main.rs
@@ -1,4 +1,4 @@
-#![feature(async_await, await_macro)]
+#![feature(async_await)]
 
 #[macro_use]
 extern crate stdweb;
@@ -24,32 +24,32 @@ fn javascript_promise() -> PromiseFuture< u32 > {
 
 async fn print( message: &str ) {
     // Waits for 2000 milliseconds
-    await!( wait( 2000 ) );
+    wait( 2000 ).await;
     console!( log, message );
 }
 
 
 async fn future_main() -> Result< (), Error > {
     // Runs Futures synchronously
-    await!( print( "Hello" ) );
-    await!( print( "There" ) );
+    print( "Hello" ).await;
+    print( "There" ).await;
 
     {
         // Runs multiple Futures in parallel
-        let ( a, b ) = await!( join(
+        let ( a, b ) = join(
             print( "Test 1" ),
             print( "Test 2" ),
-        ) );
+        ).await;
 
         console!( log, "join", a, b );
     }
 
     {
         // Runs multiple Futures (which can error) in parallel
-        let ( a, b ) = await!( try_join(
+        let ( a, b ) = try_join(
             javascript_promise(),
             javascript_promise(),
-        ) )?;
+        ).await?;
 
         console!( log, "try_join", a, b );
     }


### PR DESCRIPTION
Update the futures example to work with current nightlies (tested with 2019-08-18). I also added the futures example to the examples workspace.