### PR TITLE
test compatability with wasm-bindgen-test

### DIFF
--- a/wasm-bindgen-test-tests/Cargo.toml
+++ b/wasm-bindgen-test-tests/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "wasm-bindgen-test-tests"
+version = "0.1.0"
+edition = "2018"
+
+[dependencies]
+stdweb = { path = ".." }
+
+[dev-dependencies]
+wasm-bindgen-test = "0.3.1"

--- a/wasm-bindgen-test-tests/Web.toml
+++ b/wasm-bindgen-test-tests/Web.toml
@@ -1,0 +1,2 @@
+default-target = "wasm32-unknown-unknown"
+prepend-js = "src/runtime.js"

--- a/wasm-bindgen-test-tests/tests/document_test.rs
+++ b/wasm-bindgen-test-tests/tests/document_test.rs
@@ -1,0 +1,6 @@
+use wasm_bindgen_test::{wasm_bindgen_test, wasm_bindgen_test_configure};
+wasm_bindgen_test_configure!(run_in_browser);
+#[wasm_bindgen_test]
+fn test_document() {
+    stdweb::web::document();
+}


### PR DESCRIPTION
Using a `stdweb::web::document` is throwing this error when using more recent wasm-bindgen versions. yew [has pinned wasm-bindgen](https://github.com/yewstack/yew/pull/586), but we'd like to solve this error and [unpin it](https://github.com/yewstack/yew/pull/681). The error is reproducible with the included `wasm-bindgen-test-tests` project. 

``` rust
Camerons-MacBook-Pro:wasm-bindgen-test-tests cameron$ wasm-pack test --headless --chrome
[INFO]: 🎯  Checking for the Wasm target...
    Finished dev [unoptimized + debuginfo] target(s) in 0.05s
    Finished dev [unoptimized + debuginfo] target(s) in 0.04s
     Running target/wasm32-unknown-unknown/debug/deps/wasm_bindgen_test_tests-14dedb7b2289854e.wasm
no tests to run!
     Running target/wasm32-unknown-unknown/debug/deps/document_test-190eafa36aa6a696.wasm
Running headless tests in Chrome on `http://127.0.0.1:54185/`
Try find `webdriver.json` for configure browser's capabilities:
Not found
running 1 test                                    

test document_test::test_document ... FAIL

failures:

---- document_test::test_document output ----
    error output:
        wasm-bindgen: imported JS function that was not marked as `catch` threw an error: expected a number argument
        
        Stack:
        Error: expected a number argument
            at _assertNum (http://127.0.0.1:54184/wasm-bindgen-test:13:39)
            at imports.wbg.__wbg_cargowebsnippet1c30acb32a1994a07c75e804ae9855b43f191d63_beff0ef6225b5524 (http://127.0.0.1:54184/wasm-bindgen-test:460:13)
            at stdweb::webcore::initialization::initialize::snippet::__cargo_web_snippet_1c30acb32a1994a07c75e804ae9855b43f191d63::__cargo_web_snippet_1c30acb32a1994a07c75e804ae9855b43f191d63::h7df65e5a13b5c08b (wasm-function[1466]:0x8954a)
            at stdweb::webcore::initialization::initialize::snippet::__cargo_web_snippet_1c30acb32a1994a07c75e804ae9855b43f191d63::h08a91fb78ff13b17 (wasm-function[2803]:0x9e5a7)
            at stdweb::webcore::initialization::initialize::snippet::h159764e57bc60ee2 (wasm-function[2859]:0x9e96c)
            at stdweb::webcore::initialization::initialize::h74eac3fb2fb95962 (wasm-function[986]:0x7a2c9)
            at stdweb::webcore::ffi::wasm_bindgen::get_module::h3780a0a3f813de61 (wasm-function[2617]:0x9ce1d)
            at stdweb::webapi::document::document::snippet::__cargo_web_snippet_6fcce0aae651e2d748e085ff1f800f87625ff8c8::h5a740501719abd13 (wasm-function[1938]:0x936ae)
            at stdweb::webapi::document::document::snippet::h6c21bc5413f9c44b (wasm-function[2086]:0x95f5f)
            at stdweb::webapi::document::document::h518319ee7a8157a1 (wasm-function[284]:0x4acc9)
    
    JS exception that was thrown:
        Error: expected a number argument
            at _assertNum (http://127.0.0.1:54184/wasm-bindgen-test:13:39)
            at imports.wbg.__wbg_cargowebsnippet1c30acb32a1994a07c75e804ae9855b43f191d63_beff0ef6225b5524 (http://127.0.0.1:54184/wasm-bindgen-test:460:13)
            at stdweb::webcore::initialization::initialize::snippet::__cargo_web_snippet_1c30acb32a1994a07c75e804ae9855b43f191d63::__cargo_web_snippet_1c30acb32a1994a07c75e804ae9855b43f191d63::h7df65e5a13b5c08b (wasm-function[1466]:0x8954a)
            at stdweb::webcore::initialization::initialize::snippet::__cargo_web_snippet_1c30acb32a1994a07c75e804ae9855b43f191d63::h08a91fb78ff13b17 (wasm-function[2803]:0x9e5a7)
            at stdweb::webcore::initialization::initialize::snippet::h159764e57bc60ee2 (wasm-function[2859]:0x9e96c)
            at stdweb::webcore::initialization::initialize::h74eac3fb2fb95962 (wasm-function[986]:0x7a2c9)
            at stdweb::webcore::ffi::wasm_bindgen::get_module::h3780a0a3f813de61 (wasm-function[2617]:0x9ce1d)
            at stdweb::webapi::document::document::snippet::__cargo_web_snippet_6fcce0aae651e2d748e085ff1f800f87625ff8c8::h5a740501719abd13 (wasm-function[1938]:0x936ae)
            at stdweb::webapi::document::document::snippet::h6c21bc5413f9c44b (wasm-function[2086]:0x95f5f)
            at stdweb::webapi::document::document::h518319ee7a8157a1 (wasm-function[284]:0x4acc9)

failures:

    document_test::test_document

test result: FAILED. 0 passed; 1 failed; 0 ignored
console.log div contained:
    wasm-bindgen: imported JS function that was not marked as `catch` threw an error:
    expected a number argument
    
    Stack:
    Error: expected a number argument
        at _assertNum (http://127.0.0.1:54184/wasm-bindgen-test:13:39)
        at imports.wbg.__wbg_cargowebsnippet1c30acb32a1994a07c75e804ae9855b43f191d63_beff0ef6225b5524 (http://127.0.0.1:54184/wasm-bindgen-test:460:13)
        at stdweb::webcore::initialization::initialize::snippet::__cargo_web_snippet_1c30acb32a1994a07c75e804ae9855b43f191d63::__cargo_web_snippet_1c30acb32a1994a07c75e804ae9855b43f191d63::h7df65e5a13b5c08b (wasm-function[1466]:0x8954a)
        at stdweb::webcore::initialization::initialize::snippet::__cargo_web_snippet_1c30acb32a1994a07c75e804ae9855b43f191d63::h08a91fb78ff13b17 (wasm-function[2803]:0x9e5a7)
        at stdweb::webcore::initialization::initialize::snippet::h159764e57bc60ee2 (wasm-function[2859]:0x9e96c)
        at stdweb::webcore::initialization::initialize::h74eac3fb2fb95962 (wasm-function[986]:0x7a2c9)
        at stdweb::webcore::ffi::wasm_bindgen::get_module::h3780a0a3f813de61 (wasm-function[2617]:0x9ce1d)
        at stdweb::webapi::document::document::snippet::__cargo_web_snippet_6fcce0aae651e2d748e085ff1f800f87625ff8c8::h5a740501719abd13 (wasm-function[1938]:0x936ae)
        at stdweb::webapi::document::document::snippet::h6c21bc5413f9c44b (wasm-function[2086]:0x95f5f)
        at stdweb::webapi::document::document::h518319ee7a8157a1 (wasm-function[284]:0x4acc9)

error: some tests failed                          
error: test failed, to rerun pass '--test document_test'
Error: Running Wasm tests with wasm-bindgen-test failed
Caused by: failed to execute `cargo test`: exited with exit code: 1
```