### PR TITLE
XmlHttpRequest add get_all_response_headers method

### DIFF
--- a/src/webapi/xml_http_request.rs
+++ b/src/webapi/xml_http_request.rs
@@ -185,6 +185,20 @@ impl XmlHttpRequest {
         }
     }
 
+    /// Returns the string containing the text of all the request headers.
+    /// The headers are separated separated by CRLF.
+    ///
+    /// [(JavaScript docs)](https://developer.mozilla.org/en-US/docs/Web/API/XMLHttpRequest/getAllResponseHeaders)
+    // https://xhr.spec.whatwg.org/#ref-for-dom-xmlhttprequest-getallresponseheaders
+    pub fn get_all_response_headers(&self) -> Option<String> {
+        let headers = js!( return @{self}.getAllResponseHeaders(); );
+        match headers {
+            Value::Null => None,
+            Value::String(text) => Some(text),
+            _ => unreachable!(),
+        }
+    }
+
     /// Sets the value of an HTTP request header. Must be called after `open()`,
     /// but before `send()`. If this method is called several times with the same
     /// header, the values are merged into one single request header.


### PR DESCRIPTION
get_all_response_headers allow one to retrieve all response
headers and so they can be iterated over.

Example converting headers to hyper::http::HeaderMap
```
let xhr = XmlHttpRequest::new();
let raw_headers = xhr.get_all_response_headers();
let headers = match raw_headers {
    Some(rh) => {
        let mut headers = http::header::HeaderMap::new();
        for h in rh.split("\r\n") {
            if h.len() == 0 {
                continue;
            }
            let parts: Vec<&str> = h.split(": ").collect();
            let k = parts[0];
            let k = http::header::HeaderName::from_bytes(k.as_bytes()).unwrap();
            let v = parts[1..].join(": ");
            let v = http::header::HeaderValue::from_str(&v).unwrap();
            headers.append(k, v);
        }
        headers
    },
    None => http::header::HeaderMap::new(),
};
```