### PR TITLE
Replace sha1 dependency with sha-1

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,9 +92,8 @@ Exposing Rust functions to JavaScript is supported too:
 ```rust
 #[js_export]
 fn hash( string: String ) -> String {
-    let mut hasher = Sha1::new();
-    hasher.update( string.as_bytes() );
-    hasher.digest().to_string()
+    let hash = Sha1::digest( string.as_bytes() );
+    format!( "{:x}", hash )
 }
 ```
 

--- a/examples/hasher/Cargo.toml
+++ b/examples/hasher/Cargo.toml
@@ -8,4 +8,4 @@ crate-type = ["cdylib"]
 
 [dependencies]
 stdweb = { path = "../.." }
-sha1 = "0.3"
+sha-1 = "0.8"

--- a/examples/hasher/README.md
+++ b/examples/hasher/README.md
@@ -32,13 +32,12 @@ extern crate stdweb;
 extern crate sha1;
 
 use stdweb::js_export;
-use sha1::Sha1;
+use sha1::{Digest, Sha1};
 
 #[js_export]
 fn sha1( string: String ) -> String {
-    let mut hasher = Sha1::new();
-    hasher.update( string.as_bytes() );
-    hasher.digest().to_string()
+    let hash = Sha1::digest( string.as_bytes() );
+    format!( "{:x}", hash )
 }
 ```
 

--- a/examples/hasher/src/lib.rs
+++ b/examples/hasher/src/lib.rs
@@ -3,11 +3,10 @@ extern crate stdweb;
 extern crate sha1;
 
 use stdweb::js_export;
-use sha1::Sha1;
+use sha1::{Digest, Sha1};
 
 #[js_export]
 fn sha1( string: &str ) -> String {
-    let mut hasher = Sha1::new();
-    hasher.update( string.as_bytes() );
-    hasher.digest().to_string()
+    let hash = Sha1::digest( string.as_bytes() );
+    format!( "{:x}", hash )
 }

--- a/stdweb-internal-macros/Cargo.toml
+++ b/stdweb-internal-macros/Cargo.toml
@@ -21,7 +21,7 @@ serde = "1"
 serde_derive = "1"
 serde_json = "1"
 proc-macro2 = "1"
-sha1 = "0.6"
+sha-1 = "0.8"
 
 [dependencies.syn]
 version = "1"

--- a/stdweb-internal-macros/src/js_shim.rs
+++ b/stdweb-internal-macros/src/js_shim.rs
@@ -5,7 +5,7 @@ use std::fmt::Write;
 
 use syn;
 use proc_macro2::{TokenStream, Span};
-use sha1::Sha1;
+use sha1::{Digest, Sha1};
 
 use utils::{Target, dummy_idents};
 
@@ -17,9 +17,8 @@ struct Snippet {
 }
 
 fn hash( string: &str ) -> String {
-    let mut hasher = Sha1::new();
-    hasher.update( string.as_bytes() );
-    format!( "{}", hasher.digest() )
+    let hash = Sha1::digest( string.as_bytes() );
+    format!( "{:x}", hash )
 }
 
 fn database_path() -> PathBuf {


### PR DESCRIPTION
This other crate is being maintained, and its API is simpler and more generic when using other [RustCrypto crates](https://github.com/RustCrypto/hashes) as well.