### PR TITLE
Fix warnings

### DIFF
--- a/src/ecosystem/serde.rs
+++ b/src/ecosystem/serde.rs
@@ -168,15 +168,15 @@ impl Serialize for Value {
                 } else if Object::instance_of( reference ) {
                     let object: Object = reference.try_into().unwrap();
                     let value: BTreeMap< String, Value > = object.into();
-                    let mut map = try!( serializer.serialize_map( Some( value.len() ) ) );
+                    let mut map = serializer.serialize_map( Some( value.len() ) )?;
                     for (key, value) in value {
-                        try!( map.serialize_key( &key ) );
-                        try!( map.serialize_value( &value ) );
+                        map.serialize_key( &key )?;
+                        map.serialize_value( &value )?;
                     }
 
                     map.end()
                 } else {
-                    let map = try!( serializer.serialize_map( None ) );
+                    let map = serializer.serialize_map( None )?;
                     map.end()
                 }
             }

--- a/src/ecosystem/serde.rs
+++ b/src/ecosystem/serde.rs
@@ -328,20 +328,15 @@ impl ConversionError {
 
 impl fmt::Display for ConversionError {
     fn fmt( &self, formatter: &mut fmt::Formatter ) -> Result< (), fmt::Error > {
-        let message = error::Error::description( self );
-        write!( formatter, "{}", message )
-    }
-}
-
-impl error::Error for ConversionError {
-    fn description( &self ) -> &str {
         match self.kind {
-            ConversionErrorKind::InvalidKey => "key must be either a string or an integer",
-            ConversionErrorKind::NumberConversionError( ref error ) => error.description(),
-            ConversionErrorKind::Custom( ref message ) => message.as_str()
+            ConversionErrorKind::InvalidKey => write!( formatter, "key must be either a string or an integer" ),
+            ConversionErrorKind::NumberConversionError( ref error ) => write!( formatter, "{}", error ),
+            ConversionErrorKind::Custom( ref message ) => write!( formatter, "{}", message ),
         }
     }
 }
+
+impl error::Error for ConversionError {}
 
 impl ser::Error for ConversionError {
     fn custom< T: fmt::Display >( message: T ) -> Self {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -604,11 +604,7 @@ pub mod private {
         }
     }
 
-    impl std::error::Error for TODO {
-        fn description( &self ) -> &str {
-            unreachable!();
-        }
-    }
+    impl std::error::Error for TODO {}
 
     pub use webcore::value::ConversionError;
 }

--- a/src/webapi/document.rs
+++ b/src/webapi/document.rs
@@ -1,6 +1,8 @@
 use webcore::value::{Reference, Value};
 use webcore::try_from::{TryInto, TryFrom};
+#[cfg(feature = "experimental_features_which_may_break_on_minor_version_bumps")]
 use webcore::promise::{Promise, TypedPromise};
+#[cfg(feature = "experimental_features_which_may_break_on_minor_version_bumps")]
 use webapi::error::TypeError;
 use webapi::event_target::{IEventTarget, EventTarget};
 use webapi::node::{INode, Node, CloneKind};

--- a/src/webapi/element.rs
+++ b/src/webapi/element.rs
@@ -315,8 +315,8 @@ pub enum InsertPosition {
     AfterEnd,
 }
 
-/// Errors thrown by `Element::insert_adjacent_html`.
 error_enum_boilerplate! {
+    /// Errors thrown by `Element::insert_adjacent_html`.
     InsertAdjacentError,
     NoModificationAllowedError, SyntaxError
 }

--- a/src/webapi/element.rs
+++ b/src/webapi/element.rs
@@ -1,6 +1,8 @@
 use webcore::value::Reference;
 use webcore::try_from::{TryFrom, TryInto};
+#[cfg(feature = "experimental_features_which_may_break_on_minor_version_bumps")]
 use webcore::promise::{Promise, TypedPromise};
+#[cfg(feature = "experimental_features_which_may_break_on_minor_version_bumps")]
 use webapi::error::TypeError;
 use webapi::dom_exception::{InvalidCharacterError, InvalidPointerId, NoModificationAllowedError, SyntaxError};
 use webapi::event_target::{IEventTarget, EventTarget};

--- a/src/webapi/error.rs
+++ b/src/webapi/error.rs
@@ -83,7 +83,7 @@ mod test {
         let mut text = String::new();
         write!(&mut text, "{}", error).unwrap();
         assert_eq!(&text, "Error: foo");
-        assert_eq!(std::error::Error::description(&error), "Error");
+        assert_eq!(format!("{}", error), "Error");
     }
 
     #[test]

--- a/src/webapi/html_elements/select.rs
+++ b/src/webapi/html_elements/select.rs
@@ -18,11 +18,7 @@ impl std::fmt::Display for UnknownValueError {
     }
 }
 
-impl std::error::Error for UnknownValueError {
-    fn description(&self) -> &str {
-        "There is no `<option>` element that has the given value"
-    }
-}
+impl std::error::Error for UnknownValueError {}
 
 /// The HTML `<select>` element represents a control that provides a menu of options.
 ///

--- a/src/webapi/node.rs
+++ b/src/webapi/node.rs
@@ -344,8 +344,8 @@ pub trait INode: IEventTarget {
     }
 }
 
-/// Errors thrown by `Node` insertion methods.
 error_enum_boilerplate! {
+    /// Errors thrown by `Node` insertion methods.
     InsertNodeError,
     NotFoundError, HierarchyRequestError
 }

--- a/src/webapi/web_socket.rs
+++ b/src/webapi/web_socket.rs
@@ -277,14 +277,14 @@ impl WebSocket {
     }
 }
 
-/// Errors thrown by `WebSocket::new`.
 error_enum_boilerplate! {
+    /// Errors thrown by `WebSocket::new`.
     CreationError,
     SecurityError, SyntaxError
 }
 
-/// Errors thrown by `WebSocket::close_with_status`.
 error_enum_boilerplate! {
+    /// Errors thrown by `WebSocket::close_with_status`.
     CloseError,
     InvalidAccessError, SyntaxError
 }

--- a/src/webcore/number.rs
+++ b/src/webcore/number.rs
@@ -33,19 +33,14 @@ pub enum ConversionError {
 
 impl fmt::Display for ConversionError {
     fn fmt( &self, formatter: &mut fmt::Formatter ) -> Result< (), fmt::Error > {
-        let message = error::Error::description( self );
-        write!( formatter, "{}", message )
-    }
-}
-
-impl error::Error for ConversionError {
-    fn description( &self ) -> &str {
         match *self {
-            ConversionError::OutOfRange => "number out of range",
-            ConversionError::NotAnInteger => "number not an integer"
+            ConversionError::OutOfRange => write!( formatter, "number out of range" ),
+            ConversionError::NotAnInteger => write!( formatter, "number not an integer" ),
         }
     }
 }
+
+impl error::Error for ConversionError {}
 
 // We don't want to make the inner value public, hence this accessor.
 #[inline]

--- a/src/webcore/promise.rs
+++ b/src/webcore/promise.rs
@@ -1,5 +1,7 @@
 use std;
+#[cfg(feature = "experimental_features_which_may_break_on_minor_version_bumps")]
 use std::fmt;
+#[cfg(feature = "experimental_features_which_may_break_on_minor_version_bumps")]
 use std::marker::PhantomData;
 
 use discard::Discard;
@@ -304,9 +306,11 @@ impl Promise {
 }
 
 /// A statically typed `Promise`.
+#[cfg(feature = "experimental_features_which_may_break_on_minor_version_bumps")]
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct TypedPromise< T, E >( Promise, PhantomData< (T, E) > );
 
+#[cfg(feature = "experimental_features_which_may_break_on_minor_version_bumps")]
 impl< T, E > TypedPromise< T, E >
     where T: TryFrom< Value >,
           E: TryFrom< Value >
@@ -327,6 +331,7 @@ impl< T, E > TypedPromise< T, E >
     }
 }
 
+#[cfg(feature = "experimental_features_which_may_break_on_minor_version_bumps")]
 impl< T, E > From< TypedPromise< T, E > > for Promise {
     #[inline]
     fn from( promise: TypedPromise< T, E > ) -> Promise {

--- a/src/webcore/serialization.rs
+++ b/src/webcore/serialization.rs
@@ -412,7 +412,10 @@ macro_rules! untagged_boilerplate {
             #[inline]
             fn from( untagged: $untagged_type ) -> Self {
                 unsafe {
-                    let mut value: SerializedValue = mem::uninitialized();
+                    let mut value: SerializedValue = {
+                        let uninit = mem::MaybeUninit::uninit();
+                        uninit.assume_init()
+                    };
                     *(&mut value as *mut SerializedValue as *mut $untagged_type) = untagged;
                     value.tag = $tag;
                     value

--- a/src/webcore/type_name.rs
+++ b/src/webcore/type_name.rs
@@ -1,10 +1,7 @@
 #[cfg(rust_nightly)]
 pub fn type_name_opt< T >() -> Option< &'static str > {
     use std::intrinsics;
-    let name = unsafe {
-        intrinsics::type_name::< T >()
-    };
-
+    let name = intrinsics::type_name::< T >();
     Some( name )
 }
 

--- a/src/webcore/value.rs
+++ b/src/webcore/value.rs
@@ -862,16 +862,7 @@ impl fmt::Display for ConversionError {
     }
 }
 
-impl error::Error for ConversionError {
-    fn description( &self ) -> &str {
-        match *self {
-            ConversionError::TypeMismatch { .. } => "type mismatch",
-            ConversionError::NumericConversionError( ref inner ) => inner.description(),
-            ConversionError::ValueConversionError( _ ) => "value conversion error",
-            ConversionError::Custom( ref message ) => message
-        }
-    }
-}
+impl error::Error for ConversionError {}
 
 impl From< number::ConversionError > for ConversionError {
     fn from( inner: number::ConversionError ) -> Self {


### PR DESCRIPTION
`std::error::Error` has its `description()` function deprecated since Rust 1.41.0.

`std::mem::uninitialized()` and `try!()`, since 1.39.0.

The rest were pretty mechanical fixes hinted by the compiler.