### PR TITLE
Fix resolution of `wasm_bindgen` in `js!` macro

### DIFF
--- a/stdweb-internal-macros/src/js_shim.rs
+++ b/stdweb-internal-macros/src/js_shim.rs
@@ -115,6 +115,7 @@ pub fn js_shim_extern_code( target: Target, code: &str, arg_count: usize, return
             let shim_name = &shim_name;
             let shim_args = &shim_args;
             quote! {
+                use ::stdweb::private::wasm_bindgen;
                 use ::stdweb::private::wasm_bindgen::prelude::*;
                 unsafe fn #shim_name( #(#shim_args),* ) #return_signature {
                     #[wasm_bindgen(inline_js = #code_string)]


### PR DESCRIPTION
This fixes an issue that, when a dependent crate depends on `stdweb` for the use of the `js!` macro but does not specify the dependency `wasm_bindgen`, attempting to build for the target `wasm32-unknown-unknown` (or using `wasm-pack` and friends) will yield the following error:

    error[E0433]: failed to resolve: use of undeclared type or module `wasm_bindgen`

---
Steps to reproduce/verify:

1. Apply the following change:
```patch
diff --git a/examples/Cargo.toml b/examples/Cargo.toml
index 6cc4623..129d50e 100644
--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -1,2 +1,5 @@
 [workspace]
 members = ["canvas", "drag", "echo", "futures", "gamepad", "hasher", "minimal", "todomvc", "webgl", "wasm-bindgen-minimal"]
+
+[patch.crates-io]
+stdweb = { path = ".." }
diff --git a/examples/wasm-bindgen-minimal/Cargo.toml b/examples/wasm-bindgen-minimal/Cargo.toml
index 848c70e..a29056b 100644
--- a/examples/wasm-bindgen-minimal/Cargo.toml
+++ b/examples/wasm-bindgen-minimal/Cargo.toml
@@ -10,3 +10,4 @@ crate-type = ["cdylib"]
 [dependencies]
 wasm-bindgen = "0.2"
 stdweb = { path = "../.." }
+instant = { version = "=0.1.2", features = [ "stdweb" ]}
diff --git a/examples/wasm-bindgen-minimal/src/lib.rs b/examples/wasm-bindgen-minimal/src/lib.rs
index 70c7517..bad6967 100644
--- a/examples/wasm-bindgen-minimal/src/lib.rs
+++ b/examples/wasm-bindgen-minimal/src/lib.rs
@@ -10,5 +10,7 @@ pub fn main() -> Result<(), JsValue> {
         alert( @{message} );
     }
 
+    instant::Instant::now();
+
     Ok(())
 }
```
2. From the directory `examples/wasm-bindgen-minimal/`, execute the command `cargo build --lib --target wasm32-unknown-unknown`.