### PR TITLE
Import wasm_bindgen in macros

### DIFF
--- a/stdweb-internal-macros/src/js_shim.rs
+++ b/stdweb-internal-macros/src/js_shim.rs
@@ -115,7 +115,7 @@ pub fn js_shim_extern_code( target: Target, code: &str, arg_count: usize, return
             let shim_name = &shim_name;
             let shim_args = &shim_args;
             quote! {
-                use ::stdweb::private::wasm_bindgen::prelude::*;
+                use ::stdweb::private::wasm_bindgen::{self, prelude::*};
                 unsafe fn #shim_name( #(#shim_args),* ) #return_signature {
                     #[wasm_bindgen(inline_js = #code_string)]
                     extern "C" {


### PR DESCRIPTION
This would fix (or make unnecessary) brendanzab/gl-rs#528, which was an attempt to fix `webgl_stdweb` compiling under `wasm-pack`/`wasm-bindgen`. It was giving me these kind of errors:

```
❯ cargo c --target wasm32-unknown-unknown
    Checking webgl_stdweb v0.3.0 (/home/coolreader18/gl-rs/webgl_stdweb)
error[E0433]: failed to resolve: use of undeclared type or module `wasm_bindgen`
    --> /home/coolreader18/gl-rs/target/wasm32-unknown-unknown/debug/build/webgl_stdweb-fd022828f1f02c5e/out/bindings.rs:5789:9
     |
5789 | /         js!(
5790 | |             return true;
5791 | |         ).try_into().unwrap()
     | |_________^ use of undeclared type or module `wasm_bindgen`
     |
     = note: this error originates in an attribute macro (in Nightly builds, run with -Z macro-backtrace for more info)

error[E0433]: failed to resolve: use of undeclared type or module `wasm_bindgen`
    --> /home/coolreader18/gl-rs/target/wasm32-unknown-unknown/debug/build/webgl_stdweb-fd022828f1f02c5e/out/bindings.rs:5769:24
     |
5769 | #[derive(Debug, Clone, ReferenceType)]
     |                        ^^^^^^^^^^^^^ use of undeclared type or module `wasm_bindgen`
     |
     = note: this error originates in an attribute macro (in Nightly builds, run with -Z macro-backtrace for more info)

error[E0433]: failed to resolve: use of undeclared type or module `wasm_bindgen`
    --> /home/coolreader18/gl-rs/target/wasm32-unknown-unknown/debug/build/webgl_stdweb-fd022828f1f02c5e/out/bindings.rs:5760:24
     |
5760 | #[derive(Debug, Clone, ReferenceType)]
     |                        ^^^^^^^^^^^^^ use of undeclared type or module `wasm_bindgen`
     |
     = note: this error originates in an attribute macro (in Nightly builds, run with -Z macro-backtrace for more info)
... 1600 total errors 
```

I was able to patch it by just adding `wasm-bindgen` as a dep to `webgl_stdweb`, but I realized I was also able to fix it directly in stdweb by importing `wasm_bindgen` inside the `js!()`/`derive(ReferenceType)` macros. I think it was failing because `wasm-bindgen`'s macros expect to be able to access `wasm_bindgen`, but because crates invoking the `stdweb` macros that invoke the `wasm-bindgen` macros don't necessarily have `wasm_bindgen` in scope, it might fail to compile.