### PR TITLE
use MaybeUninit instead of uninitialized

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,10 +17,10 @@ build = "build.rs"
 discard = "1.0.3"
 serde = { version = "1", optional = true }
 serde_json = { version = "1", optional = true }
-futures-core-preview = { version = "0.3.0-alpha.15", optional = true }
-futures-channel-preview = { version = "0.3.0-alpha.15", optional = true }
-futures-util-preview = { version = "0.3.0-alpha.15", optional = true }
-futures-executor-preview = { version = "0.3.0-alpha.15", optional = true }
+futures-core = { version = "0.3.8", optional = true }
+futures-channel = { version = "0.3.8", optional = true }
+futures-util = { version = "0.3.8", optional = true }
+futures-executor = { version = "0.3.8", optional = true }
 
 stdweb-derive = { version = "= 0.5.3", path = "stdweb-derive" }
 stdweb-internal-macros = { version = "= 0.2.9", path = "stdweb-internal-macros" }
@@ -44,7 +44,7 @@ rustc_version = "0.2"
 default = ["serde", "serde_json"]
 nightly = []
 web_test = []
-futures-support = ["futures-core-preview", "futures-channel-preview", "futures-util-preview", "futures-executor-preview"]
+futures-support = ["futures-core", "futures-channel", "futures-util", "futures-executor"]
 experimental_features_which_may_break_on_minor_version_bumps = ["futures-support"]
 "docs-rs" = []
 

--- a/src/webcore/promise_future.rs
+++ b/src/webcore/promise_future.rs
@@ -110,9 +110,9 @@ use super::promise::{Promise, DoneHandle};
 ///    }
 ///    ```
 #[inline]
-pub fn spawn_local< F >( future: F ) where F: Future< Output = () > + 'static {
+pub fn spawn_local< F >( future: F ) where F: Future< Output = () > + 'static{
     // TODO does this need to use PinBox instead ?
-    let future: executor::BoxedFuture = Box::new( future ).into();
+    let future = Box::new( future ).into();
     executor::spawn_local( future );
 }
 

--- a/src/webcore/serialization.rs
+++ b/src/webcore/serialization.rs
@@ -412,8 +412,9 @@ macro_rules! untagged_boilerplate {
             #[inline]
             fn from( untagged: $untagged_type ) -> Self {
                 unsafe {
-                    let mut value: SerializedValue = mem::uninitialized();
-                    *(&mut value as *mut SerializedValue as *mut $untagged_type) = untagged;
+                    let mut value = mem::MaybeUninit::<SerializedValue>::uninit();
+                    *(value.as_mut_ptr() as *mut $untagged_type) = untagged;
+                    let mut value = value.assume_init();
                     value.tag = $tag;
                     value
                 }


### PR DESCRIPTION
Latest versions of rust will panic when trying to leave an uninitialized SerializedValue from mem::uninitialized which was breaking the js! macro