### PR TITLE
Marked reserve function as unsafe

### DIFF
--- a/src/webcore/global_arena.rs
+++ b/src/webcore/global_arena.rs
@@ -66,7 +66,7 @@ pub fn serialize_value< 'a >( value: Value ) -> SerializedValue< 'a > {
 }
 
 #[inline]
-pub fn reserve< 'a, T >( length: usize ) -> RelativeSlice< 'a, T > {
+pub unsafe fn reserve< 'a, T >( length: usize ) -> RelativeSlice< 'a, T > {
     unsafe {
         let offset = reserve_impl( length * mem::size_of::< T >(), mem::align_of::< T >() );
         debug_assert_eq!( ARENA.memory.offset( offset as isize ) as usize % mem::align_of::< T >(), 0 );

--- a/src/webcore/serialization.rs
+++ b/src/webcore/serialization.rs
@@ -707,7 +707,7 @@ impl< T: JsSerialize > JsSerialize for [T] {
     #[doc(hidden)]
     #[inline]
     fn _into_js< 'a >( &'a self ) -> SerializedValue< 'a > {
-        let mut output = global_arena::reserve( self.len() );
+        let mut output = unsafe { global_arena::reserve( self.len() ) };
         for value in self {
             unsafe {
                 output.append( value._into_js() );
@@ -734,8 +734,8 @@ impl< T: JsSerialize > JsSerialize for Vec< T > {
 __js_serializable_boilerplate!( impl< T > for Vec< T > where T: JsSerialize );
 
 fn object_into_js< 'a, K: AsRef< str >, V: 'a + JsSerialize, I: Iterator< Item = (K, &'a V) > + ExactSizeIterator >( iter: I ) -> SerializedValue< 'a > {
-    let mut keys = global_arena::reserve( iter.len() );
-    let mut values = global_arena::reserve( iter.len() );
+    let mut keys = unsafe { global_arena::reserve( iter.len() ) };
+    let mut values = unsafe { global_arena::reserve( iter.len() ) };
     for (key, value) in iter {
         unsafe {
             keys.append( key.as_ref()._into_js().as_string().clone() );


### PR DESCRIPTION
https://github.com/koute/stdweb/blob/9b418d98df6fafaa4d4b87b04c304d0220292055/src/webcore/global_arena.rs#L69-L76
hello, if a function's entire body is unsafe, the function is itself unsafe and should be marked appropriately. Marking them unsafe also means that callers must make sure they know what they're doing.